### PR TITLE
FEAT/FIX: bug fixes and additions

### DIFF
--- a/README.md
+++ b/README.md
@@ -214,13 +214,19 @@ const App = () => {
 
 ---
 
+### `undo: () => void;`
+
+Undoes the last made move on the board. Can be done multiple times in a row as long as resetBoard is not called.
+
+---
+
 ### `highlight: (_: { square: Square; color?: string }) => void;`
 
 Highlight a square on the chessboard. The default color is `'rgba(255,255,0, 0.5)'`. 
 
 ---
 
-### `resetAllHighlightedSquares: () => void`
+### `resetAllHighlightedSquares: () => void;`
 
 ---
 

--- a/src/context/board-context-provider.tsx
+++ b/src/context/board-context-provider.tsx
@@ -30,6 +30,10 @@ const ChessboardContextProviderComponent = React.forwardRef<
   const chessboardController: ChessboardRef = useMemo(() => {
     return {
       move: (params) => chessboardRef.current?.move?.(params),
+      undo: () => {
+        chessboardRef.current?.undo();
+        boardOperationsRef.current?.reset();
+      },
       highlight: (params) => chessboardRef.current?.highlight(params),
       resetAllHighlightedSquares: () =>
         chessboardRef.current?.resetAllHighlightedSquares(),

--- a/src/context/board-operations-context/index.tsx
+++ b/src/context/board-operations-context/index.tsx
@@ -121,7 +121,7 @@ const BoardOperationsContextProviderComponent = React.forwardRef<
       const isCheckmate = chess.in_checkmate();
 
       if (isCheckmate) {
-        const square = findKing(`${chess.turn()}k`);
+        const square = findKing(chess.turn() === 'b' ? 'bk' : 'wk');
         if (!square) return;
         controller?.highlight({ square, color: checkmateHighlight });
       }
@@ -193,6 +193,20 @@ const BoardOperationsContextProviderComponent = React.forwardRef<
 
       // eslint-disable-next-line no-shadow
       selectableSquares.value = validSquares.map((square) => {
+        // handle castling
+        if (square.toString() == 'O-O') {
+          if (chess.turn() === 'w') {
+            return 'g1';
+          } else {
+            return 'g8';
+          }
+        } else if (square.toString() == 'O-O-O') {
+          if (chess.turn() === 'w') {
+            return 'c1';
+          } else {
+            return 'c8';
+          }
+        }
         const splittedSquare = square.split('x');
         if (splittedSquare.length === 0) {
           return square;

--- a/src/context/board-promotion-context/dialog/index.tsx
+++ b/src/context/board-promotion-context/dialog/index.tsx
@@ -20,6 +20,8 @@ const PromotionDialog: React.FC<Required<BoardPromotionContextState>> =
         style={[
           {
             width: boardSize / 3,
+            left: boardSize / 3,
+            top: boardSize / 3,
           },
           styles.container,
         ]}

--- a/src/context/board-promotion-context/index.tsx
+++ b/src/context/board-promotion-context/index.tsx
@@ -11,9 +11,7 @@ export type BoardPromotionContextType = {
 };
 
 const BoardPromotionContext = React.createContext<BoardPromotionContextType>({
-  showPromotionDialog: () => {
-    //
-  },
+  showPromotionDialog: () => {},
   isPromoting: false,
 });
 

--- a/src/context/board-refs-context/index.tsx
+++ b/src/context/board-refs-context/index.tsx
@@ -26,6 +26,7 @@ const SquareRefsContext = createContext<React.MutableRefObject<Record<
 > | null> | null>(null);
 
 export type ChessboardRef = {
+  undo: () => void;
   move: (_: {
     from: Square;
     to: Square;
@@ -77,6 +78,10 @@ const BoardRefsContextProviderComponent = React.forwardRef<
     () => ({
       move: ({ from, to }) => {
         return pieceRefs?.current?.[from].current?.moveTo?.(to);
+      },
+      undo: () => {
+        chess.undo();
+        setBoard(chess.board());
       },
       highlight: ({ square, color }) => {
         squareRefs.current?.[square].current.highlight({

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -13,6 +13,7 @@ import {
 } from './context/props-context';
 import { useChessboardProps } from './context/props-context/hooks';
 import type { ChessboardState } from './helpers/get-chessboard-state';
+import { GestureHandlerRootView } from 'react-native-gesture-handler';
 
 const styles = StyleSheet.create({
   container: {
@@ -43,6 +44,7 @@ const ChessboardContainerComponent = React.forwardRef<
     ref,
     () => ({
       move: (params) => chessboardRef.current?.move?.(params),
+      undo: () => chessboardRef.current?.undo(),
       highlight: (params) => chessboardRef.current?.highlight(params),
       resetAllHighlightedSquares: () =>
         chessboardRef.current?.resetAllHighlightedSquares(),
@@ -53,11 +55,13 @@ const ChessboardContainerComponent = React.forwardRef<
   );
 
   return (
-    <ChessboardPropsContextProvider {...props}>
-      <ChessboardContextProvider ref={chessboardRef} fen={props.fen}>
-        <Chessboard />
-      </ChessboardContextProvider>
-    </ChessboardPropsContextProvider>
+    <GestureHandlerRootView>
+      <ChessboardPropsContextProvider {...props}>
+        <ChessboardContextProvider ref={chessboardRef} fen={props.fen}>
+          <Chessboard />
+        </ChessboardContextProvider>
+      </ChessboardPropsContextProvider>
+    </GestureHandlerRootView>
   );
 });
 


### PR DESCRIPTION
Hi there!

I have made some changes to the chessboard component that I would like to submit in this pull request. Firstly, I have added an undo function that allows the user to undo a made move.

Secondly, I have centered the promotion dialogue in the middle of the chessboard component. This makes it easier for the user to see the options available to them when promoting a pawn.

Thirdly, I fixed an issue with castling not working properly. This was caused by the onSelectPiece function not handling the special notation that castling uses. I have updated the function to handle this properly so that castling now works as expected.

Lastly, I noticed an issue where the user is unable to promote twice. If they try to promote a second time, the dialogue showing the piece options simply does not show up and the pawn is stuck on the 8th/1st rank without the user being able to move any other pieces. I'm hoping you will have a solution for this issue.

Thank you for considering my pull request!