### PR TITLE
Expose history prop in getChessboardState

### DIFF
--- a/src/helpers/get-chessboard-state.ts
+++ b/src/helpers/get-chessboard-state.ts
@@ -10,6 +10,7 @@ type ChessboardStateFunctions = Pick<
   | 'insufficient_material'
   | 'game_over'
   | 'fen'
+  | 'history'
 >;
 
 type RecordReturnTypes<T> = {
@@ -28,5 +29,6 @@ export const getChessboardState = (chess: ChessInstance): ChessboardState => {
     insufficient_material: chess.insufficient_material(),
     game_over: chess.game_over(),
     fen: chess.fen(),
+    history: chess.history({ verbose: true })
   };
 };


### PR DESCRIPTION
This PR adds the history property to the object returned by getChessboardState. The history array contains detailed information about all moves made in the current game.

Why?

- Access to move history is essential for features like game replay and move analysis.

- Currently, only the FEN string and basic information are exposed, making it difficult to reconstruct or review the game.