### PR TITLE
refactor: tighten internal index re-exports

### DIFF
--- a/src/hooks/index.ts
+++ b/src/hooks/index.ts
@@ -1,3 +1,1 @@
-export { useBoardGesture } from './use-board-gesture';
-export { useChessboardRef } from './use-chessboard-ref';
 export type { ChessboardRef } from './use-chessboard-ref';

--- a/src/state/index.ts
+++ b/src/state/index.ts
@@ -1,4 +1,8 @@
-export * from './types';
-export * from './use-board-state';
-export * from './board-state-context';
-export * from './move-executor';
+export type { BoardConfig, BoardState } from './types';
+export {
+  BoardStateProvider,
+  useBoardContext,
+  useBoardConfig,
+  useBoardStateValues,
+} from './board-state-context';
+export type { BoardStateProviderProps } from './board-state-context';


### PR DESCRIPTION
## Summary

\`src/state/index.ts\` and \`src/hooks/index.ts\` used wildcard re-exports that surfaced internals no consumer imports through the index path. Narrow them to only the symbols that are actually consumed via the index.

### Before / after

\`src/state/index.ts\`
- Was: \`export * from './types' | './use-board-state' | './board-state-context' | './move-executor'\`
- Now: explicit named re-exports of \`BoardConfig\`, \`BoardState\`, \`BoardStateProvider\`, \`BoardStateProviderProps\`, \`useBoardContext\`, \`useBoardConfig\`, \`useBoardStateValues\`

\`src/hooks/index.ts\`
- Was: \`useBoardGesture\`, \`useChessboardRef\`, \`ChessboardRef\`
- Now: \`ChessboardRef\` type only

### Why

Internal call sites already use direct subpath imports (\`'../../state/move-executor'\`, \`'../../hooks/use-chessboard-ref'\`, etc.), so narrowing the index does not move any line of code. The wildcard re-exports were leaking helpers like \`createMoveExecutor\`, \`useBoardState\`, \`squareToPosition\`, \`useBoardGesture\` through the index path even though no one imported them that way.

No public API change — \`src/index.tsx\` is the only public entry point, and its exports are unchanged.

## Test plan

- [ ] CI green (Lint, Typecheck, Format, Test, Build)
- [ ] Public type/runtime exports from \`react-native-chessboard\` unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)