### PR TITLE
ci: opt actions into Node.js 24 runtime

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -10,6 +10,9 @@ concurrency:
   group: ${{ github.workflow }}-${{ github.ref }}
   cancel-in-progress: true
 
+env:
+  FORCE_JAVASCRIPT_ACTIONS_TO_NODE24: 'true'
+
 jobs:
   lint:
     name: Lint


### PR DESCRIPTION
## Summary

\`actions/checkout@v4\` and \`actions/cache@v4\` currently run on Node.js 20, which GitHub deprecates on June 2nd 2026 (default flips to Node 24) and removes from runners on September 16th 2026. Setting \`FORCE_JAVASCRIPT_ACTIONS_TO_NODE24=true\` at the workflow level opts every step into the new runtime now.

### Effect
- Silences the deprecation warning that currently appears on every CI run.
- Removes the risk of a surprise break when GitHub flips the default in June.
- Can be removed once \`actions/checkout\` and \`actions/cache\` ship versions targeting Node 24 natively.

## Test plan

- [ ] CI green (Lint, Typecheck, Format, Test, Build).
- [ ] No more "Node.js 20 actions are deprecated" annotations on the run.

🤖 Generated with [Claude Code](https://claude.com/claude-code)