### PR TITLE
feat: support custom piece sprite sheets via spriteSource prop

### DIFF
--- a/README.md
+++ b/README.md
@@ -23,6 +23,7 @@ A high-performing, zero-render chessboard for React Native built with Skia and R
 - [react-native-reanimated (>= 3.6.0)](https://docs.swmansion.com/react-native-reanimated/docs)
 - [react-native-gesture-handler (>= 2.14.0)](https://docs.swmansion.com/react-native-gesture-handler/docs/)
 - [@shopify/react-native-skia (>= 1.0.0)](https://shopify.github.io/react-native-skia/)
+- [react-native-worklets (>= 0.3.0)](https://docs.swmansion.com/react-native-worklets/docs/)
 
 ```sh
 bun add react-native-chessboard
@@ -144,15 +145,76 @@ Default:
 
 ---
 
+### `spriteSource?: ImageSourcePropType`
+
+Override the bundled piece sprite sheet with your own. Falls back to the default sheet when omitted.
+
+```jsx
+<Chessboard spriteSource={require('./assets/my-pieces.png')} />
+```
+
+The sheet must follow the standard layout the library expects:
+
+- 6×2 grid (12 cells total)
+- Each cell is **128×128 pixels**
+- **Row 0:** white pieces in order `p, n, b, r, q, k`
+- **Row 1:** black pieces in same order
+
+```
+col:  0(p)  1(n)  2(b)  3(r)  4(q)  5(k)
+row 0: wp    wn    wb    wr    wq    wk    ← white
+row 1: bp    bn    bb    br    bq    bk    ← black
+total: 768 × 256
+```
+
+Any `ImageSourcePropType` is accepted: `require(...)`, `{ uri }`, etc.
+
+#### Generating a sheet from individual piece images
+
+If you only have 12 individual PNGs (one per piece) and need to compose them into a single sheet, the library ships a CLI for that:
+
+```sh
+npx react-native-chessboard-generate-sprite \
+  --input ./my-pieces \
+  --output ./assets/my-sprite.png
+```
+
+The input directory must contain these files:
+
+```
+wp.png wn.png wb.png wr.png wq.png wk.png
+bp.png bn.png bb.png br.png bq.png bk.png
+```
+
+Options:
+
+- `--input <dir>` — directory holding the 12 PNGs
+- `--output <path>` — output sheet path
+- `--cell-size=<n>` — cell size in pixels (default `128`)
+
+The script depends on [`sharp`](https://www.npmjs.com/package/sharp); install it first if you don't already have it:
+
+```sh
+npm install --save-dev sharp
+```
+
+Then point `spriteSource` at the generated file:
+
+```jsx
+<Chessboard spriteSource={require('./assets/my-sprite.png')} />
+```
+
+---
+
 ## Ref API
 
 The chessboard exposes a ref for programmatic control:
 
-```jsx
+```tsx
 import Chessboard, { ChessboardRef } from 'react-native-chessboard';
 
 const App = () => {
-  const chessboardRef = useRef < ChessboardRef > null;
+  const chessboardRef = useRef<ChessboardRef>(null);
 
   useEffect(() => {
     (async () => {
@@ -213,7 +275,7 @@ Returns the current state of the chessboard.
    - `game_over` → `isGameOver`
    - `in_promotion` → `isPromotion`
 
-4. **`renderPiece` prop removed**: Custom piece rendering is no longer supported in v2.0
+4. **`renderPiece` prop removed**: Per-piece JSX rendering is no longer supported in v2.0. Use `spriteSource` to swap the entire piece set instead (see above).
 
 ### Migration Steps
 

--- a/package.json
+++ b/package.json
@@ -10,12 +10,16 @@
   "files": [
     "src",
     "lib",
+    "scripts/generate-sprite.js",
     "!lib/typescript/example",
     "!**/__tests__",
     "!**/__fixtures__",
     "!**/__mocks__",
     "!**/*.map"
   ],
+  "bin": {
+    "react-native-chessboard-generate-sprite": "./scripts/generate-sprite.js"
+  },
   "scripts": {
     "test": "jest",
     "typecheck": "tsc --noEmit",

--- a/scripts/generate-sprite.js
+++ b/scripts/generate-sprite.js
@@ -1,65 +1,123 @@
 #!/usr/bin/env node
 /**
- * Generates a sprite sheet from individual piece images.
+ * Generates a sprite sheet from a set of 12 individual piece images.
  *
- * Layout: 6x2 grid (6 piece types x 2 colors)
- * Row 0: white pieces (p, n, b, r, q, k)
- * Row 1: black pieces (p, n, b, r, q, k)
+ * Layout produced:
+ *   6x2 grid (6 piece types x 2 colors)
+ *   Row 0: white pieces in order p, n, b, r, q, k
+ *   Row 1: black pieces in same order
  *
- * Usage: node scripts/generate-sprite.js [--cell-size=128]
+ * Input directory must contain these filenames:
+ *   wp.png wn.png wb.png wr.png wq.png wk.png
+ *   bp.png bn.png bb.png br.png bq.png bk.png
  *
- * Requires: npm install sharp
+ * Usage:
+ *   npx react-native-chessboard-generate-sprite \
+ *     --input ./my-pieces \
+ *     --output ./assets/my-sprite.png \
+ *     [--cell-size=128]
+ *
+ * If --input/--output are omitted the script falls back to the
+ * library's own src/assets directory (used when iterating on the
+ * bundled sprite during library development).
+ *
+ * Requires: sharp.
+ *   npm install --save-dev sharp
  */
 
 const fs = require('fs');
 const path = require('path');
 
+function parseArgs(argv) {
+  const opts = { input: null, output: null, cellSize: 128 };
+  for (let i = 0; i < argv.length; i++) {
+    const arg = argv[i];
+    if (arg.startsWith('--input=')) opts.input = arg.split('=')[1];
+    else if (arg === '--input') opts.input = argv[++i] || null;
+    else if (arg.startsWith('--output=')) opts.output = arg.split('=')[1];
+    else if (arg === '--output') opts.output = argv[++i] || null;
+    else if (arg.startsWith('--cell-size=')) {
+      opts.cellSize = parseInt(arg.split('=')[1], 10);
+    } else if (arg === '--help' || arg === '-h') {
+      opts.help = true;
+    }
+  }
+  return opts;
+}
+
+function printHelp() {
+  console.log(
+    [
+      '',
+      'generate-sprite — compose 12 piece PNGs into a chessboard sprite sheet',
+      '',
+      'Usage:',
+      '  generate-sprite [--input <dir>] [--output <path>] [--cell-size=128]',
+      '',
+      'Options:',
+      '  --input <dir>     Directory containing wp.png ... bk.png (12 files)',
+      '  --output <path>   Output sprite PNG path',
+      '  --cell-size=N     Cell size in pixels (default: 128)',
+      '  -h, --help        Show this help',
+      '',
+      'Without --input/--output, generates from src/assets in the library',
+      'itself (development mode).',
+      '',
+    ].join('\n')
+  );
+}
+
 async function generateSprite() {
-  // Try to load sharp dynamically
+  const opts = parseArgs(process.argv.slice(2));
+
+  if (opts.help) {
+    printHelp();
+    process.exit(0);
+  }
+
   let sharp;
   try {
     sharp = require('sharp');
   } catch {
     console.error('Error: sharp package is required.');
-    console.error('Install it with: npm install sharp --save-dev');
+    console.error('Install it with: npm install --save-dev sharp');
     process.exit(1);
   }
 
-  const assetsDir = path.resolve(__dirname, '../src/assets');
-  const outputPath = path.resolve(assetsDir, 'pieces-sprite.png');
+  const libAssetsDir = path.resolve(__dirname, '../src/assets');
+  const inputDir = opts.input
+    ? path.resolve(process.cwd(), opts.input)
+    : libAssetsDir;
+  const outputPath = opts.output
+    ? path.resolve(process.cwd(), opts.output)
+    : path.join(libAssetsDir, 'pieces-sprite.png');
+  const cellSize = opts.cellSize;
 
-  // Parse command line arguments
-  const args = process.argv.slice(2);
-  let cellSize = 128;
-
-  for (const arg of args) {
-    if (arg.startsWith('--cell-size=')) {
-      cellSize = parseInt(arg.split('=')[1], 10);
-    }
+  if (!Number.isFinite(cellSize) || cellSize <= 0) {
+    console.error(`Error: invalid --cell-size: ${opts.cellSize}`);
+    process.exit(1);
   }
 
-  // Piece order: pawns, knights, bishops, rooks, queens, kings
+  if (!fs.existsSync(inputDir) || !fs.statSync(inputDir).isDirectory()) {
+    console.error(`Error: input directory not found: ${inputDir}`);
+    process.exit(1);
+  }
+
   const pieceOrder = ['p', 'n', 'b', 'r', 'q', 'k'];
   const colors = ['w', 'b'];
 
-  const spriteWidth = cellSize * 6;
-  const spriteHeight = cellSize * 2;
-
-  // Create composite operations
   const composites = [];
-
   for (let colorIndex = 0; colorIndex < colors.length; colorIndex++) {
     const color = colors[colorIndex];
     for (let pieceIndex = 0; pieceIndex < pieceOrder.length; pieceIndex++) {
       const piece = pieceOrder[pieceIndex];
       const filename = `${color}${piece}.png`;
-      const filepath = path.join(assetsDir, filename);
-
+      const filepath = path.join(inputDir, filename);
       if (!fs.existsSync(filepath)) {
-        console.error(`Error: Missing piece image: ${filename}`);
+        console.error(`Error: missing piece image: ${filename}`);
+        console.error(`  Expected at: ${filepath}`);
         process.exit(1);
       }
-
       composites.push({
         input: filepath,
         left: pieceIndex * cellSize,
@@ -68,9 +126,12 @@ async function generateSprite() {
     }
   }
 
-  // Create the sprite sheet
+  const spriteWidth = cellSize * 6;
+  const spriteHeight = cellSize * 2;
+
+  fs.mkdirSync(path.dirname(outputPath), { recursive: true });
+
   try {
-    // Create a transparent base image
     const base = sharp({
       create: {
         width: spriteWidth,
@@ -80,7 +141,6 @@ async function generateSprite() {
       },
     });
 
-    // Resize all input images to cellSize and composite them
     const resizedComposites = await Promise.all(
       composites.map(async (comp) => ({
         input: await sharp(comp.input)

--- a/src/__mocks__/react-native-skia.ts
+++ b/src/__mocks__/react-native-skia.ts
@@ -9,7 +9,7 @@ export const Circle = () => null;
 export const Image = () => null;
 export const Atlas = () => null;
 
-export const useImage = () => null;
+export const useImage = jest.fn(() => null);
 
 // Utility function to create SkRect-like objects
 export const rect = (x: number, y: number, width: number, height: number) => ({

--- a/src/__tests__/generate-sprite.test.ts
+++ b/src/__tests__/generate-sprite.test.ts
@@ -1,0 +1,170 @@
+import { spawnSync } from 'child_process';
+import * as fs from 'fs';
+import * as os from 'os';
+import * as path from 'path';
+import sharp from 'sharp';
+
+const SCRIPT = path.resolve(__dirname, '../../scripts/generate-sprite.js');
+const PIECES = ['p', 'n', 'b', 'r', 'q', 'k'] as const;
+const COLORS = ['w', 'b'] as const;
+
+const ALL_FILENAMES = COLORS.flatMap((c) => PIECES.map((p) => `${c}${p}.png`));
+
+const makeFixturePiece = async (filepath: string, color: 'w' | 'b') => {
+  // Solid square so we can detect it composited correctly. White pieces
+  // get a red tile, black pieces get a blue tile — distinct enough to
+  // verify position via pixel sampling if a future test wants to.
+  const r = color === 'w' ? 255 : 0;
+  const b = color === 'b' ? 255 : 0;
+  await sharp({
+    create: {
+      width: 32,
+      height: 32,
+      channels: 4,
+      background: { r, g: 0, b, alpha: 255 },
+    },
+  })
+    .png()
+    .toFile(filepath);
+};
+
+const populateFixtureDir = async (
+  dir: string,
+  filenames: readonly string[] = ALL_FILENAMES
+) => {
+  fs.mkdirSync(dir, { recursive: true });
+  for (const filename of filenames) {
+    const color = filename[0] as 'w' | 'b';
+    await makeFixturePiece(path.join(dir, filename), color);
+  }
+};
+
+const runScript = (
+  args: string[]
+): { status: number; stdout: string; stderr: string } => {
+  const result = spawnSync('node', [SCRIPT, ...args], {
+    encoding: 'utf8',
+  });
+  return {
+    status: result.status ?? -1,
+    stdout: result.stdout,
+    stderr: result.stderr,
+  };
+};
+
+describe('generate-sprite CLI', () => {
+  let tmpRoot: string;
+
+  beforeEach(() => {
+    tmpRoot = fs.mkdtempSync(path.join(os.tmpdir(), 'gen-sprite-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tmpRoot, { recursive: true, force: true });
+  });
+
+  it('prints usage and exits 0 on --help', () => {
+    const { status, stdout } = runScript(['--help']);
+    expect(status).toBe(0);
+    expect(stdout).toContain('generate-sprite');
+    expect(stdout).toContain('--input');
+    expect(stdout).toContain('--output');
+    expect(stdout).toContain('--cell-size');
+  });
+
+  it('produces a 768x256 sheet from a complete fixture dir at default cell size', async () => {
+    const inputDir = path.join(tmpRoot, 'pieces');
+    const outputPath = path.join(tmpRoot, 'sprite.png');
+    await populateFixtureDir(inputDir);
+
+    const { status } = runScript(['--input', inputDir, '--output', outputPath]);
+
+    expect(status).toBe(0);
+    expect(fs.existsSync(outputPath)).toBe(true);
+
+    const meta = await sharp(outputPath).metadata();
+    expect(meta.width).toBe(768); // 6 cols * 128
+    expect(meta.height).toBe(256); // 2 rows * 128
+  });
+
+  it('honors --cell-size for output dimensions', async () => {
+    const inputDir = path.join(tmpRoot, 'pieces');
+    const outputPath = path.join(tmpRoot, 'sprite.png');
+    await populateFixtureDir(inputDir);
+
+    const { status } = runScript([
+      '--input',
+      inputDir,
+      '--output',
+      outputPath,
+      '--cell-size=64',
+    ]);
+
+    expect(status).toBe(0);
+    const meta = await sharp(outputPath).metadata();
+    expect(meta.width).toBe(64 * 6);
+    expect(meta.height).toBe(64 * 2);
+  });
+
+  it('creates intermediate output directories', async () => {
+    const inputDir = path.join(tmpRoot, 'pieces');
+    const outputPath = path.join(tmpRoot, 'nested', 'a', 'b', 'sprite.png');
+    await populateFixtureDir(inputDir);
+
+    const { status } = runScript(['--input', inputDir, '--output', outputPath]);
+
+    expect(status).toBe(0);
+    expect(fs.existsSync(outputPath)).toBe(true);
+  });
+
+  it('fails with exit 1 when the input directory does not exist', () => {
+    const inputDir = path.join(tmpRoot, 'missing');
+    const outputPath = path.join(tmpRoot, 'sprite.png');
+
+    const { status, stderr } = runScript([
+      '--input',
+      inputDir,
+      '--output',
+      outputPath,
+    ]);
+
+    expect(status).toBe(1);
+    expect(stderr).toContain('input directory not found');
+  });
+
+  it('fails with exit 1 when a required piece file is missing', async () => {
+    const inputDir = path.join(tmpRoot, 'pieces');
+    const outputPath = path.join(tmpRoot, 'sprite.png');
+    // Skip the white queen on purpose
+    const incomplete = ALL_FILENAMES.filter((f) => f !== 'wq.png');
+    await populateFixtureDir(inputDir, incomplete);
+
+    const { status, stderr } = runScript([
+      '--input',
+      inputDir,
+      '--output',
+      outputPath,
+    ]);
+
+    expect(status).toBe(1);
+    expect(stderr).toContain('missing piece image');
+    expect(stderr).toContain('wq.png');
+  });
+
+  it('rejects an invalid --cell-size value', async () => {
+    const inputDir = path.join(tmpRoot, 'pieces');
+    const outputPath = path.join(tmpRoot, 'sprite.png');
+    await populateFixtureDir(inputDir);
+
+    const { status, stderr } = runScript([
+      '--input',
+      inputDir,
+      '--output',
+      outputPath,
+      '--cell-size=abc',
+    ]);
+
+    expect(status).toBe(1);
+    expect(stderr).toContain('invalid --cell-size');
+  });
+});

--- a/src/__tests__/piece-images.test.ts
+++ b/src/__tests__/piece-images.test.ts
@@ -1,0 +1,54 @@
+import { useImage } from '@shopify/react-native-skia';
+import { usePieceSpriteSheet } from '../assets/piece-images';
+
+const useImageMock = useImage as jest.Mock;
+
+describe('usePieceSpriteSheet', () => {
+  beforeEach(() => {
+    useImageMock.mockClear();
+    useImageMock.mockReturnValue(null);
+  });
+
+  it('forwards the bundled sprite source to useImage when no override is given', () => {
+    usePieceSpriteSheet();
+
+    expect(useImageMock).toHaveBeenCalledTimes(1);
+    const passedSource = useImageMock.mock.calls[0][0];
+    // Metro+jest resolve `require('./pieces-sprite.png')` to the file mock.
+    // ts-jest re-wraps the default export, so the value is the module object.
+    expect(passedSource).toBeDefined();
+  });
+
+  it('forwards a custom asset source verbatim', () => {
+    const customSource = 999 as const;
+    usePieceSpriteSheet(customSource);
+
+    expect(useImageMock).toHaveBeenCalledTimes(1);
+    expect(useImageMock).toHaveBeenCalledWith(customSource);
+  });
+
+  it('forwards a custom uri source verbatim', () => {
+    const customSource = { uri: 'https://example.com/my-sprite.png' };
+    usePieceSpriteSheet(customSource);
+
+    expect(useImageMock).toHaveBeenCalledTimes(1);
+    expect(useImageMock).toHaveBeenCalledWith(customSource);
+  });
+
+  it('returns the SkImage produced by useImage', () => {
+    const fakeSkImage = { __brand: 'SkImage' } as unknown;
+    useImageMock.mockReturnValueOnce(fakeSkImage);
+
+    const result = usePieceSpriteSheet();
+
+    expect(result.image).toBe(fakeSkImage);
+  });
+
+  it('returns null while the image is decoding (useImage returns null)', () => {
+    useImageMock.mockReturnValueOnce(null);
+
+    const result = usePieceSpriteSheet();
+
+    expect(result.image).toBeNull();
+  });
+});

--- a/src/assets/piece-images.ts
+++ b/src/assets/piece-images.ts
@@ -1,9 +1,22 @@
+import type { ImageSourcePropType } from 'react-native';
 import { useImage } from '@shopify/react-native-skia';
 
-const SPRITE_SOURCE = require('./pieces-sprite.png');
+const DEFAULT_SPRITE_SOURCE = require('./pieces-sprite.png');
 
-export const usePieceSpriteSheet = () => {
-  const image = useImage(SPRITE_SOURCE);
+/**
+ * Loads the piece sprite sheet.
+ *
+ * Default sheet layout (used when no custom source is provided):
+ * - 6×2 grid, 128×128 cells
+ * - Row 0: white pieces in order p, n, b, r, q, k
+ * - Row 1: black pieces in same order
+ *
+ * Custom sheets must follow the same layout. Use the bundled
+ * `react-native-chessboard-generate-sprite` script to compose
+ * 12 individual PNGs into a compatible sheet.
+ */
+export const usePieceSpriteSheet = (source?: ImageSourcePropType) => {
+  const image = useImage(source ?? DEFAULT_SPRITE_SOURCE);
   return { image };
 };
 

--- a/src/components/skia/gesture-board.tsx
+++ b/src/components/skia/gesture-board.tsx
@@ -6,6 +6,7 @@ import React, {
   useRef,
 } from 'react';
 import { View, StyleSheet } from 'react-native';
+import type { ImageSourcePropType } from 'react-native';
 import {
   GestureDetector,
   GestureHandlerRootView,
@@ -47,14 +48,15 @@ export interface GestureBoardProps {
   onMove?: (result: MoveResult) => void;
   onIllegalMove?: (from: Square, to: Square) => void;
   renderEffect?: (params: EffectParams) => React.ReactNode;
+  spriteSource?: ImageSourcePropType;
 }
 
 export const GestureBoard = forwardRef<ChessboardRef, GestureBoardProps>(
-  ({ onMove, onIllegalMove, renderEffect }, ref) => {
+  ({ onMove, onIllegalMove, renderEffect, spriteSource }, ref) => {
     const { chess } = useBoardContext();
     const config = useBoardConfig();
     const boardState = useBoardStateValues();
-    const { image: spriteImage } = usePieceSpriteSheet();
+    const { image: spriteImage } = usePieceSpriteSheet(spriteSource);
 
     // Effect state for shader effects (all SharedValues for reactivity)
     const effectCenterX = useSharedValue(0);

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -1,4 +1,5 @@
 import React, { forwardRef } from 'react';
+import type { ImageSourcePropType } from 'react-native';
 import type { Move, Square } from 'chess.js';
 import { BoardStateProvider } from './state';
 import type { BoardStateProviderProps } from './state';
@@ -13,6 +14,12 @@ export interface ChessboardProps
   onMove?: (result: MoveResult) => void;
   onIllegalMove?: (from: Square, to: Square) => void;
   renderEffect?: (params: EffectParams) => React.ReactNode;
+  /**
+   * Optional custom piece sprite sheet. Must match the standard
+   * 6×2 / 128px-cell layout (row 0 = white p,n,b,r,q,k; row 1 =
+   * black). Falls back to the bundled sheet when omitted.
+   */
+  spriteSource?: ImageSourcePropType;
 }
 
 const Chessboard = forwardRef<ChessboardRef, ChessboardProps>(
@@ -29,6 +36,7 @@ const Chessboard = forwardRef<ChessboardRef, ChessboardProps>(
       onMove,
       onIllegalMove,
       renderEffect,
+      spriteSource,
     },
     ref
   ) => {
@@ -48,6 +56,7 @@ const Chessboard = forwardRef<ChessboardRef, ChessboardProps>(
           onMove={onMove}
           onIllegalMove={onIllegalMove}
           renderEffect={renderEffect}
+          spriteSource={spriteSource}
         />
       </BoardStateProvider>
     );


### PR DESCRIPTION
## Summary

Until now the bundled `pieces-sprite.png` was hardcoded — consumers who wanted a different piece set had to fork the library. This PR adds a public escape hatch.

### New `spriteSource` prop

```tsx
<Chessboard spriteSource={require('./assets/my-pieces.png')} />
```

- Type: `ImageSourcePropType` (any `require(...)`, `{ uri }`, etc.)
- Falls back to the bundled sheet when omitted — existing consumers see no change.
- Threaded through `<Chessboard>` → `<GestureBoard>` → `usePieceSpriteSheet(source?)`.
- Custom sheets must follow the standard layout: 6×2 grid, **128×128** cells, white row 0 / black row 1, piece order `p,n,b,r,q,k`. Matches what `SkiaPiecesAtlas` already expects; layout-configurable sheets stay out of scope.

### Sprite generator CLI

`scripts/generate-sprite.js` was a dev-only helper. Rewritten to accept `--input` / `--output` / `--cell-size` flags and exposed via `bin` as **`react-native-chessboard-generate-sprite`**. Ships in the package (`files` updated). Falls back to the library's own `src/assets` path when invoked without flags (preserves the dev workflow).

```sh
npx react-native-chessboard-generate-sprite \
  --input ./my-pieces \
  --output ./assets/my-sprite.png
```

Requires `sharp` as a one-off dev dep on the consumer side (`npm install --save-dev sharp`).

### Tests

`src/__tests__/piece-images.test.ts` (5 cases):
- Default sprite forwarded to `useImage` when no source passed
- Custom asset `number` source forwarded verbatim
- Custom `{ uri }` source forwarded verbatim
- `SkImage` returned by `useImage` is exposed via `{ image }`
- Returns `null` while image decodes

The skia mock now wraps `useImage` in `jest.fn` so calls are inspectable.

### Docs

README updates:
- New section under Properties documenting `spriteSource` + layout spec + generator CLI
- v1→v2 migration note for the removed `renderPiece` prop now points at `spriteSource`
- Adds `react-native-worklets` to peer-deps list (was already a runtime peer after PR #27)

### What is _not_ in this PR

- Layout configurability (cell size, piece order, color mapping). The layout is locked to the 6×2/128px standard. Could be relaxed later by exposing layout constants alongside the prop.
- Promotion-dialog atlas migration (PR #31, closed). Once consumers can ship their own sheet, the dialog still uses individual PNGs — separate cleanup.

## Test plan

- [ ] CI green (Lint, Typecheck, Format, Test, Build).
- [ ] `scripts/generate-sprite.js --help` prints usage.
- [ ] `scripts/generate-sprite.js --input <dir> --output <path>` produces a sheet at the right path with the correct layout.
- [ ] In example app: pass `spriteSource={require('./assets/some-other-sprite.png')}` and verify pieces render from the custom sheet.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
