### PR TITLE
fix: reset renderEffect SharedValues on resetBoard

### DIFF
--- a/src/__tests__/promotion-cancel.test.ts
+++ b/src/__tests__/promotion-cancel.test.ts
@@ -83,6 +83,7 @@ const config: BoardConfig = {
     scale: SCALE_SPRING,
     snapBack: SNAP_BACK_SPRING,
   },
+  fontSource: null,
 };
 
 // Mirror of the cancel path in gesture-board.tsx's handlePromotionCancel.

--- a/src/__tests__/render-effect-reset.test.ts
+++ b/src/__tests__/render-effect-reset.test.ts
@@ -1,0 +1,171 @@
+import { Chess, Square } from 'chess.js';
+import { makeMutable } from 'react-native-reanimated';
+import {
+  createMoveExecutor,
+  type EffectSharedValues,
+} from '../state/move-executor';
+import type {
+  BoardState,
+  PieceCode,
+  SquareState,
+  HighlightState,
+  BoardConfig,
+} from '../state/types';
+import { SQUARES } from '../state/types';
+import { squareToPosition } from '../state/use-board-state';
+import {
+  MOVE_SPRING,
+  SCALE_SPRING,
+  SNAP_BACK_SPRING,
+} from '../config/animations';
+import type { EffectTrigger } from '../types';
+
+const PIECE_SIZE = 50;
+
+const createMockSquareState = (
+  piece: PieceCode,
+  x: number,
+  y: number
+): SquareState => ({
+  piece: makeMutable<PieceCode>(piece),
+  translateX: makeMutable(x),
+  translateY: makeMutable(y),
+  scale: makeMutable(1),
+  zIndex: makeMutable(0),
+});
+
+const createMockHighlightState = (): HighlightState => ({
+  color: makeMutable<string | null>(null),
+});
+
+const createMockBoardState = (chess: Chess): BoardState => {
+  const squares: Partial<Record<Square, SquareState>> = {};
+  const highlights: Partial<Record<Square, HighlightState>> = {};
+  for (const square of SQUARES) {
+    const pos = squareToPosition(square, PIECE_SIZE, false);
+    const piece = chess.get(square);
+    const code: PieceCode = piece
+      ? (`${piece.color}${piece.type}` as PieceCode)
+      : null;
+    squares[square] = createMockSquareState(code, pos.x, pos.y);
+    highlights[square] = createMockHighlightState();
+  }
+  return {
+    squares: squares as Record<Square, SquareState>,
+    highlights: highlights as Record<Square, HighlightState>,
+    turn: makeMutable(chess.turn()),
+    selectedSquare: makeMutable<Square | null>(null),
+    validMoves: makeMutable<Square[]>([]),
+    lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
+    isCheck: makeMutable(false),
+    kingInCheckSquare: makeMutable<Square | null>(null),
+  };
+};
+
+const config: BoardConfig = {
+  boardSize: PIECE_SIZE * 8,
+  pieceSize: PIECE_SIZE,
+  gestureEnabled: true,
+  flipped: false,
+  withLetters: false,
+  withNumbers: false,
+  colors: {
+    white: '#fff',
+    black: '#000',
+    lastMoveHighlight: 'rgba(255,255,0,0.5)',
+    checkmateHighlight: '#E84855',
+    promotionPieceButton: '#FF9B71',
+  },
+  durations: { move: 150 },
+  animations: {
+    move: MOVE_SPRING,
+    scale: SCALE_SPRING,
+    snapBack: SNAP_BACK_SPRING,
+  },
+  fontSource: null,
+};
+
+const createEffectSharedValues = (): EffectSharedValues => ({
+  centerX: makeMutable(0),
+  centerY: makeMutable(0),
+  progress: makeMutable(0),
+  trigger: makeMutable<EffectTrigger>(''),
+});
+
+describe('renderEffect reset on resetBoard', () => {
+  it('resets effect SharedValues to defaults when resetBoard runs without a fen', () => {
+    const chess = new Chess();
+    const boardState = createMockBoardState(chess);
+    const effectSharedValues = createEffectSharedValues();
+
+    // Simulate a check/checkmate having previously written effect state.
+    effectSharedValues.centerX.set(123);
+    effectSharedValues.centerY.set(456);
+    effectSharedValues.progress.set(0.8);
+    effectSharedValues.trigger.set('checkmate');
+
+    const executor = createMoveExecutor(chess, boardState, config, {
+      effectSharedValues,
+    });
+
+    executor.resetBoard();
+
+    expect(effectSharedValues.centerX.get()).toBe(0);
+    expect(effectSharedValues.centerY.get()).toBe(0);
+    expect(effectSharedValues.progress.get()).toBe(0);
+    expect(effectSharedValues.trigger.get()).toBe('');
+  });
+
+  it('also resets effect SharedValues when resetBoard loads a custom fen', () => {
+    const chess = new Chess();
+    const boardState = createMockBoardState(chess);
+    const effectSharedValues = createEffectSharedValues();
+
+    effectSharedValues.centerX.set(200);
+    effectSharedValues.trigger.set('check');
+
+    const executor = createMoveExecutor(chess, boardState, config, {
+      effectSharedValues,
+    });
+
+    // Kiwipete
+    executor.resetBoard(
+      'r3k2r/p1ppqpb1/bn2pnp1/3PN3/1p2P3/2N2Q1p/PPPBBPPP/R3K2R w KQkq - 0 1'
+    );
+
+    expect(effectSharedValues.centerX.get()).toBe(0);
+    expect(effectSharedValues.trigger.get()).toBe('');
+  });
+
+  it('does not throw when called without effectSharedValues', () => {
+    const chess = new Chess();
+    const boardState = createMockBoardState(chess);
+    const executor = createMoveExecutor(chess, boardState, config, {});
+
+    expect(() => executor.resetBoard()).not.toThrow();
+  });
+
+  it('also resets effect SharedValues when invoked through undo()', () => {
+    const chess = new Chess();
+    const boardState = createMockBoardState(chess);
+    const effectSharedValues = createEffectSharedValues();
+
+    const executor = createMoveExecutor(chess, boardState, config, {
+      effectSharedValues,
+    });
+
+    // Make a move so undo has something to undo, then dirty the effect SVs.
+    executor.executeMove('e2' as Square, 'e4' as Square);
+    effectSharedValues.centerX.set(50);
+    effectSharedValues.centerY.set(50);
+    effectSharedValues.progress.set(0.5);
+    effectSharedValues.trigger.set('check');
+
+    executor.undo();
+
+    expect(effectSharedValues.centerX.get()).toBe(0);
+    expect(effectSharedValues.centerY.get()).toBe(0);
+    expect(effectSharedValues.progress.get()).toBe(0);
+    expect(effectSharedValues.trigger.get()).toBe('');
+  });
+});

--- a/src/components/skia/gesture-board.tsx
+++ b/src/components/skia/gesture-board.tsx
@@ -167,13 +167,31 @@ export const GestureBoard = forwardRef<ChessboardRef, GestureBoardProps>(
       [onMove, triggerEffect, chess]
     );
 
+    const effectSharedValues = useMemo(
+      () => ({
+        centerX: effectCenterX,
+        centerY: effectCenterY,
+        progress: effectProgress,
+        trigger: effectTrigger,
+      }),
+      [effectCenterX, effectCenterY, effectProgress, effectTrigger]
+    );
+
     const moveExecutor = useMemo(
       () =>
         createMoveExecutor(chess, boardState, config, {
           onMove: handleMove,
           onPromotionRequired: handlePromotionRequired,
+          effectSharedValues,
         }),
-      [chess, boardState, config, handleMove, handlePromotionRequired]
+      [
+        chess,
+        boardState,
+        config,
+        handleMove,
+        handlePromotionRequired,
+        effectSharedValues,
+      ]
     );
 
     // Setup ref API

--- a/src/state/move-executor.ts
+++ b/src/state/move-executor.ts
@@ -1,8 +1,10 @@
 import { withSpring } from 'react-native-reanimated';
+import type { SharedValue } from 'react-native-reanimated';
 import type { Chess, Move, Square, PieceSymbol } from 'chess.js';
 import type { BoardState, PieceCode } from './types';
 import { squareToPosition } from './use-board-state';
 import type { BoardConfig } from './types';
+import type { EffectTrigger } from '../types';
 import {
   getChessboardState,
   ChessboardState,
@@ -14,6 +16,13 @@ export type MoveResult = {
   state: ChessboardState & { isPromotion: boolean };
 };
 
+export type EffectSharedValues = {
+  centerX: SharedValue<number>;
+  centerY: SharedValue<number>;
+  progress: SharedValue<number>;
+  trigger: SharedValue<EffectTrigger>;
+};
+
 type MoveCallbacks = {
   onMove?: (result: MoveResult) => void;
   onPromotionRequired?: (info: {
@@ -22,6 +31,7 @@ type MoveCallbacks = {
     color: 'w' | 'b';
     complete: (piece: PieceSymbol) => void;
   }) => void;
+  effectSharedValues?: EffectSharedValues;
 };
 
 export const createMoveExecutor = (
@@ -274,6 +284,16 @@ export const createMoveExecutor = (
     // Clear highlights
     for (const square of Object.keys(boardState.highlights) as Square[]) {
       boardState.highlights[square].color.set(null);
+    }
+
+    // Reset shader effect SharedValues so a fresh game's first check or
+    // checkmate doesn't trigger a ripple at the previous game's king
+    // square (centerX/centerY were last written by triggerEffect).
+    if (callbacks.effectSharedValues) {
+      callbacks.effectSharedValues.centerX.set(0);
+      callbacks.effectSharedValues.centerY.set(0);
+      callbacks.effectSharedValues.progress.set(0);
+      callbacks.effectSharedValues.trigger.set('');
     }
   };
 


### PR DESCRIPTION
## Summary

The check / checkmate / stalemate ripple lives in the SharedValues created at the top of `GestureBoard` (`effectCenterX/Y/progress/trigger`). Each time `triggerEffect` runs, it writes the king's square coords into `centerX/Y`.

`resetBoard()` cleared chess state, square pieces, highlights, and last-move/turn/check flags — but left the effect SharedValues alone. So after a consumer called `ref.current.resetBoard()` and the next game produced a check at a *different* king square, the ripple still rendered at the previous game's king coords for one frame before `triggerEffect` overwrote them.

## Fix

Thread an optional `effectSharedValues` bag through `createMoveExecutor`'s callbacks. `resetBoard()` resets `centerX = 0`, `centerY = 0`, `progress = 0`, `trigger = ''` when present. Callers without `renderEffect` pass nothing and the path no-ops.

```ts
type EffectSharedValues = {
  centerX: SharedValue<number>;
  centerY: SharedValue<number>;
  progress: SharedValue<number>;
  trigger: SharedValue<EffectTrigger>;
};
```

`gesture-board.tsx` packs the four SharedValues into a `useMemo` bag and passes it to `createMoveExecutor`, so the executor mutates the same instances the `SkiaBoard`'s `renderEffect` slot reads.

## Tests

`src/__tests__/render-effect-reset.test.ts` (4 cases):

- `resetBoard()` with no fen wipes effect SharedValues
- `resetBoard(fen)` (custom FEN) also wipes them
- omitting `effectSharedValues` from callbacks does not throw
- `undo()` (which calls `resetBoard` internally) also wipes them

## Drive-by

A one-line fix to `src/__tests__/promotion-cancel.test.ts`: adds `fontSource: null` to its config fixture. The field landed in `BoardConfig` with #34 (after #36 was authored), so main's `tsc --noEmit` was missing the property in that test until now.

Test count: 219 → 226.

## Test plan

- [ ] CI green
- [ ] In `example/App.tsx`: trigger a checkmate (king on one square), call `ref.current.resetBoard()`, set up a different position whose checkmate king is on a different square, trigger it again. The ripple should land on the new king's square — no flicker at the old coords.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
