### PR TITLE
feat(state): expose move history on ChessboardState

### DIFF
--- a/README.md
+++ b/README.md
@@ -128,6 +128,7 @@ The `state` object contains:
 - `isGameOver: boolean`
 - `isPromotion: boolean`
 - `fen: string`
+- `history: ReadonlyArray<Move>` — verbose move history (each entry includes `from`, `to`, `san`, `color`, `promotion`, captured piece, etc.). Useful for replay, move-list UIs, and analysis.
 
 ---
 

--- a/src/__tests__/chessboard-state.test.ts
+++ b/src/__tests__/chessboard-state.test.ts
@@ -122,4 +122,70 @@ describe('getChessboardState', () => {
       expect(afterE4).toContain('4P3'); // Pawn on e4
     });
   });
+
+  describe('history tracking', () => {
+    it('returns an empty history for a fresh game', () => {
+      const chess = new Chess();
+      const state = getChessboardState(chess);
+
+      expect(state.history).toEqual([]);
+    });
+
+    it('returns verbose Move objects for each move played', () => {
+      const chess = new Chess();
+      chess.move('e4');
+      chess.move('e5');
+      chess.move('Nf3');
+
+      const state = getChessboardState(chess);
+
+      expect(state.history).toHaveLength(3);
+      expect(state.history[0]).toMatchObject({
+        from: 'e2',
+        to: 'e4',
+        san: 'e4',
+        color: 'w',
+      });
+      expect(state.history[1]).toMatchObject({
+        from: 'e7',
+        to: 'e5',
+        san: 'e5',
+        color: 'b',
+      });
+      expect(state.history[2]).toMatchObject({
+        from: 'g1',
+        to: 'f3',
+        san: 'Nf3',
+        color: 'w',
+      });
+    });
+
+    it('captures promotion details in history entries', () => {
+      const chess = new Chess('7k/4P3/8/8/8/8/8/4K3 w - - 0 1');
+      chess.move({ from: 'e7', to: 'e8', promotion: 'q' });
+
+      const state = getChessboardState(chess);
+
+      expect(state.history).toHaveLength(1);
+      expect(state.history[0]).toMatchObject({
+        from: 'e7',
+        to: 'e8',
+        promotion: 'q',
+        san: 'e8=Q+',
+      });
+    });
+
+    it('shrinks history when chess.undo runs', () => {
+      const chess = new Chess();
+      chess.move('e4');
+      chess.move('e5');
+      expect(getChessboardState(chess).history).toHaveLength(2);
+
+      chess.undo();
+      expect(getChessboardState(chess).history).toHaveLength(1);
+
+      chess.undo();
+      expect(getChessboardState(chess).history).toHaveLength(0);
+    });
+  });
 });

--- a/src/helpers/get-chessboard-state.ts
+++ b/src/helpers/get-chessboard-state.ts
@@ -1,4 +1,4 @@
-import type { Chess } from 'chess.js';
+import type { Chess, Move } from 'chess.js';
 
 export type ChessboardState = {
   readonly isCheck: boolean;
@@ -9,6 +9,7 @@ export type ChessboardState = {
   readonly isInsufficientMaterial: boolean;
   readonly isGameOver: boolean;
   readonly fen: string;
+  readonly history: ReadonlyArray<Move>;
 };
 
 export const getChessboardState = (chess: Chess): ChessboardState => {
@@ -21,5 +22,6 @@ export const getChessboardState = (chess: Chess): ChessboardState => {
     isInsufficientMaterial: chess.isInsufficientMaterial(),
     isGameOver: chess.isGameOver(),
     fen: chess.fen(),
+    history: chess.history({ verbose: true }),
   };
 };


### PR DESCRIPTION
## Summary

Adds a `history: ReadonlyArray<Move>` field to `ChessboardState`, populated via `chess.history({ verbose: true })`. Each entry carries `from`, `to`, `san`, `color`, `promotion`, captured piece, etc., so consumers can build replay UIs, move lists, or analysis features without reaching into the internal `Chess` instance.

## Credit

Re-implementation of #21 by **@patrikgafrik** against the v2 API. The original PR predated the v2 architectural rewrite (chess.js v0.x snake_case methods vs. v1.0 camelCase, plus a now-deleted `RecordReturnTypes` machinery), so it could no longer apply cleanly. Concept and motivation are unchanged; @patrikgafrik is credited via `Co-Authored-By` on the commit. Closing #21 with a pointer here.

## What this looks like

```ts
const { state } = result; // from onMove
state.history;
// [
//   { from: 'e2', to: 'e4', san: 'e4', color: 'w', piece: 'p', flags: 'b', ... },
//   { from: 'e7', to: 'e5', san: 'e5', color: 'b', piece: 'p', flags: 'b', ... },
//   ...
// ]
```

Same `state.history` is also reachable through `ref.current.getState().history`.

## Tests

`src/__tests__/chessboard-state.test.ts` — 4 new cases:

- empty history for a fresh game
- verbose `Move` objects after each move (asserts `from`, `to`, `san`, `color`)
- promotion details captured in history entries
- history shrinks when `chess.undo()` runs

Test count: 226 → 230.

## Trade-off considered

`getChessboardState` is invoked once per move in `move-executor.ts`, and `chess.history({ verbose: true })` allocates a fresh `Move[]` each call (O(n) per call, O(n²) over a game). Acceptable for typical games (≤100 moves). Not worth memoizing now; revisit if it ever shows up in a perf trace.

## Test plan

- [ ] CI green
- [ ] In the example app, log `result.state.history` from `onMove` after a few moves and confirm the array grows with verbose entries

🤖 Generated with [Claude Code](https://claude.com/claude-code)
