### PR TITLE
chore(release): 0.2.0-beta.1

### DIFF
--- a/package.json
+++ b/package.json
@@ -1,6 +1,6 @@
 {
   "name": "react-native-chessboard",
-  "version": "0.2.0-beta.0",
+  "version": "0.2.0-beta.1",
   "description": "A lightweight, simple, and high-performing chessboard for React Native",
   "main": "lib/commonjs/index",
   "module": "lib/module/index",


### PR DESCRIPTION
## Summary

Bump the in-package version to **`0.2.0-beta.1`** ahead of publishing the next beta. Once this lands on `main`, the release tag, npm publish under the `next` dist-tag, and GitHub release will follow.

## Highlights since `0.2.0-beta.0`

- CI quality gates on every PR (lint, typecheck, format, tests, build) with branch protection on `main` (#26)
- Package optimization: source maps excluded, dead code removed, per-render allocations memoized, `react-native-worklets` declared as peer dep (#27)
- Internal index re-exports tightened to public surface (#28)
- Husky hooks actually fire (#29)
- GH Actions opted into Node 24 ahead of the Sept 2026 deprecation (#30)
- Custom piece sprite sheet support via `spriteSource` + CLI generator (`npx react-native-chessboard-generate-sprite`) (#32)
- Render-test infrastructure with realistic skia mock (#33)
- Board labels (`withLetters`/`withNumbers`) actually paint; new `fontSource` prop for custom label fonts (#34)
- `fen` prop is reactive — changing it after mount rebuilds chess state (#35)
- Promotion cancel snaps the pawn back to its origin square; Android hardware-back also routes through cancel (#36)
- `renderEffect` SharedValues reset on `resetBoard()` so the next check/checkmate doesn't ripple at stale king coords (#37)
- `ChessboardState.history` exposes verbose move array (re-implementation of #21 by @patrikgafrik) (#38)

## What this PR does

- Bumps `package.json` version: `0.2.0-beta.0` → `0.2.0-beta.1`
- Nothing else.

## What happens after merge

After this lands on `main` I will:

1. `git tag v0.2.0-beta.1 && git push origin v0.2.0-beta.1`
2. `npm publish --tag next` (so `npm install react-native-chessboard@next` resolves to this beta; `latest` stays untouched)
3. `gh release create v0.2.0-beta.1 --prerelease --generate-notes`

## Test plan

- [ ] CI green
- [ ] After publish, `npm view react-native-chessboard@0.2.0-beta.1 version` returns `0.2.0-beta.1` and the `next` dist-tag points to it

🤖 Generated with [Claude Code](https://claude.com/claude-code)
