### PR TITLE
fix(promotion): resolve move() + lock board on promotion cancel

### DIFF
--- a/src/__tests__/move-executor.test.ts
+++ b/src/__tests__/move-executor.test.ts
@@ -332,6 +332,29 @@ describe('createMoveExecutor', () => {
       expect(move?.promotion).toBe('q');
     });
 
+    it('resolves undefined and does not move when promotion is cancelled', async () => {
+      const chess = new Chess('8/P7/8/8/8/8/8/4K2k w - - 0 1');
+      const boardState = createMockBoardState(chess, PIECE_SIZE);
+      const fenBefore = chess.fen();
+
+      const onPromotionRequired = jest.fn((info) => {
+        // User dismissed the picker without choosing a piece.
+        info.cancel();
+      });
+      const executor = createMoveExecutor(chess, boardState, config, {
+        onPromotionRequired,
+      });
+
+      // Would hang forever before the cancel resolver existed.
+      const move = await executor.tryMove('a7' as Square, 'a8' as Square);
+
+      expect(onPromotionRequired).toHaveBeenCalledWith(
+        expect.objectContaining({ cancel: expect.any(Function) })
+      );
+      expect(move).toBeUndefined();
+      expect(chess.fen()).toBe(fenBefore); // move never committed
+    });
+
     it('defaults to queen promotion when no handler provided', async () => {
       const chess = new Chess('8/P7/8/8/8/8/8/4K2k w - - 0 1');
       const boardState = createMockBoardState(chess, PIECE_SIZE);

--- a/src/components/skia/gesture-board.tsx
+++ b/src/components/skia/gesture-board.tsx
@@ -46,6 +46,7 @@ interface PromotionInfo {
   to: Square;
   color: 'w' | 'b';
   complete: (piece: PieceSymbol) => void;
+  cancel: () => void;
 }
 
 export interface GestureBoardProps {
@@ -76,6 +77,9 @@ export const GestureBoard = forwardRef<ChessboardRef, GestureBoardProps>(
     const [showPromotion, setShowPromotion] = useState(false);
 
     const handlePromotionRequired = useCallback((info: PromotionInfo) => {
+      // If a promotion is somehow already pending, abandon it (resolving its
+      // move() promise) before replacing it, so the old one never leaks.
+      promotionInfoRef.current?.cancel();
       promotionInfoRef.current = info;
       setShowPromotion(true);
     }, []);
@@ -112,6 +116,9 @@ export const GestureBoard = forwardRef<ChessboardRef, GestureBoardProps>(
         fromState.zIndex.set(0);
         boardState.selectedSquare.set(null);
         boardState.validMoves.set([]);
+        // Resolve the awaiting move() promise (with undefined) — the move was
+        // never executed. Without this the caller hangs forever.
+        info.cancel();
       }
       promotionInfoRef.current = null;
       setShowPromotion(false);
@@ -207,7 +214,9 @@ export const GestureBoard = forwardRef<ChessboardRef, GestureBoardProps>(
       boardState,
       config,
       moveExecutor,
-      gestureEnabled: config.gestureEnabled,
+      // Lock the board while the promotion picker is open so a second drag
+      // can't start (and re-trigger) another promotion.
+      gestureEnabled: config.gestureEnabled && !showPromotion,
       onIllegalMove,
     });
 

--- a/src/state/move-executor.ts
+++ b/src/state/move-executor.ts
@@ -31,6 +31,9 @@ type MoveCallbacks = {
     to: Square;
     color: 'w' | 'b';
     complete: (piece: PieceSymbol) => void;
+    // Abandon the promotion (e.g. the user dismissed the picker). Resolves the
+    // pending move() with undefined so awaiting callers don't hang.
+    cancel: () => void;
   }) => void;
   effectSharedValues?: EffectSharedValues;
 };
@@ -270,6 +273,9 @@ export const createMoveExecutor = (
             color: chess.turn(),
             complete: (piece: PieceSymbol) => {
               attempt(piece);
+            },
+            cancel: () => {
+              resolve(undefined);
             },
           });
         } else {


### PR DESCRIPTION
## Problem
Cancelling the promotion picker never resolved the Promise returned by `ref.move()` — the resolver lived only inside the `complete` callback. So `await ref.move({ from, to })` on a cancelled promotion **hung forever** and leaked the promise. A second drag while the dialog was open could also re-trigger promotion and orphan the first one.

## Fix (additive, non-breaking)
- Add an optional `cancel: () => void` to the `onPromotionRequired` callback info; it resolves `move()` with `undefined`.
- Call `cancel()` from the dialog's cancel path (back button / backdrop tap included).
- Cancel any superseded pending promotion before replacing it.
- Disable board gestures while the picker is open so a second drag can't start another promotion.

`cancel` is a new optional field — existing `onPromotionRequired` consumers are unaffected.

## Tests
Added: cancelling a promotion resolves `move()` with `undefined` and leaves the position unchanged (would hang before this fix). Full suite: 235 passing. lint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)