### PR TITLE
fix(state): restore last-move highlight on undo; guard invalid fen prop

### DIFF
--- a/src/__tests__/move-executor.test.ts
+++ b/src/__tests__/move-executor.test.ts
@@ -492,6 +492,34 @@ describe('createMoveExecutor', () => {
 
       expect(chess.fen()).toBe(initialFen);
     });
+
+    it('restores the previous move highlight after undo', () => {
+      const chess = new Chess();
+      const boardState = createMockBoardState(chess, PIECE_SIZE);
+      const executor = createMoveExecutor(chess, boardState, config, {});
+
+      executor.executeMove('e2' as Square, 'e4' as Square);
+      executor.executeMove('e7' as Square, 'e5' as Square);
+      executor.undo(); // take back e5 → e4 is now the last move
+
+      expect(boardState.lastMove.get()).toEqual({ from: 'e2', to: 'e4' });
+      expect(boardState.squares.e2.lastMove.get()).toBe(true);
+      expect(boardState.squares.e4.lastMove.get()).toBe(true);
+      expect(boardState.squares.e7.lastMove.get()).toBe(false);
+    });
+
+    it('clears the highlight when undoing the only move', () => {
+      const chess = new Chess();
+      const boardState = createMockBoardState(chess, PIECE_SIZE);
+      const executor = createMoveExecutor(chess, boardState, config, {});
+
+      executor.executeMove('e2' as Square, 'e4' as Square);
+      executor.undo(); // back to the start — nothing to highlight
+
+      expect(boardState.lastMove.get()).toBeNull();
+      expect(boardState.squares.e2.lastMove.get()).toBe(false);
+      expect(boardState.squares.e4.lastMove.get()).toBe(false);
+    });
   });
 
   describe('selectPiece', () => {

--- a/src/state/move-executor.ts
+++ b/src/state/move-executor.ts
@@ -420,8 +420,14 @@ export const createMoveExecutor = (
     const move = chess.undo();
     if (!move) return null;
 
-    // Reset the board to current state
-    resetBoard(chess.fen());
+    // Reset the board, restoring the last-move highlight to the move that now
+    // sits at the end of the history (rather than clearing it).
+    const history = chess.history({ verbose: true });
+    const prev = history[history.length - 1];
+    resetBoard(
+      chess.fen(),
+      prev ? { lastMove: { from: prev.from, to: prev.to } } : undefined
+    );
 
     return move;
   };

--- a/src/state/use-board-state.ts
+++ b/src/state/use-board-state.ts
@@ -180,7 +180,13 @@ export const useBoardState = (
     if (!initialFen) {
       chess.reset();
     } else {
-      chess.load(initialFen);
+      try {
+        chess.load(initialFen);
+      } catch {
+        // Invalid `fen` prop — keep the current position rather than crashing
+        // the effect (mirrors resetBoard's defensive load).
+        return;
+      }
     }
     const { pieceSize: ps, flipped: fl } = layoutRef.current;
     for (const square of SQUARES) {


### PR DESCRIPTION
## Two small correctness fixes

### undo() lost the last-move highlight
`undo()` called `resetBoard(chess.fen())` with no highlight, so stepping back went dark. Now it re-highlights the move that becomes the latest in history (and clears it when undoing the only move).

### Invalid `fen` prop crashed the effect
The `initialFen` effect called `chess.load(fen)` unguarded, so an invalid `fen` prop threw inside a render-phase effect. Wrapped in try/catch — keeps the current position, mirroring `resetBoard`'s defensive load.

## Tests
Added: undo restores the prior move's highlight; undo of the only move clears it. Full suite: 236 passing. lint + tsc clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)