### PR TITLE
feat(a11y): screen-reader support for board + promotion dialog

### DIFF
--- a/src/__mocks__/react-native-reanimated.ts
+++ b/src/__mocks__/react-native-reanimated.ts
@@ -46,6 +46,13 @@ export const withSpring = <T>(
 
 export const runOnJS = (fn: Function) => fn;
 
+// No-op in tests: the reaction's side effects (re-render ticks) aren't needed
+// for assertions on rendered output.
+export const useAnimatedReaction = (
+  _prepare: () => unknown,
+  _react: Function
+) => undefined;
+
 export const Easing = {
   out: (easing: any) => easing,
   quad: (t: number) => t * t,
@@ -58,5 +65,6 @@ export default {
   withTiming,
   withSpring,
   runOnJS,
+  useAnimatedReaction,
   Easing,
 };

--- a/src/__tests__/accessibility-layer.test.tsx
+++ b/src/__tests__/accessibility-layer.test.tsx
@@ -1,0 +1,139 @@
+import React from 'react';
+import TestRenderer, { act } from 'react-test-renderer';
+import { Chess } from 'chess.js';
+import { makeMutable } from 'react-native-reanimated';
+import type { Square } from 'chess.js';
+
+// react-native isn't transformed by this jest setup; stub the two primitives
+// the layer uses so it can mount under react-test-renderer.
+jest.mock('react-native', () => ({
+  View: 'View',
+  StyleSheet: {
+    create: (s: Record<string, unknown>) => s,
+    absoluteFill: {
+      position: 'absolute',
+      left: 0,
+      top: 0,
+      right: 0,
+      bottom: 0,
+    },
+  },
+}));
+
+import { AccessibilityLayer } from '../components/accessibility-layer';
+import { SQUARES } from '../state/types';
+import { squareToPosition } from '../state/use-board-state';
+import type { BoardConfig, BoardState, PieceCode } from '../state/types';
+import type { MoveExecutor } from '../state/move-executor';
+
+const makeBoardState = (chess: Chess): BoardState => {
+  const squares = {} as BoardState['squares'];
+  for (const square of SQUARES) {
+    const p = chess.get(square);
+    squares[square] = {
+      piece: makeMutable<PieceCode>(
+        p ? (`${p.color}${p.type}` as PieceCode) : null
+      ),
+    } as unknown as BoardState['squares'][Square];
+  }
+  return {
+    squares,
+    turn: makeMutable(chess.turn()),
+    selectedSquare: makeMutable<Square | null>(null),
+    validMoves: makeMutable<Square[]>([]),
+    lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
+  } as unknown as BoardState;
+};
+
+const config = {
+  pieceSize: 50,
+  flipped: false,
+} as unknown as BoardConfig;
+
+const findByLabel = (root: TestRenderer.ReactTestInstance, label: string) =>
+  root.findAll((n) => n.props?.accessibilityLabel === label);
+
+describe('AccessibilityLayer', () => {
+  it('labels every square with its contents', () => {
+    const chess = new Chess();
+    const boardState = makeBoardState(chess);
+    const moveExecutor = {
+      selectPiece: jest.fn(),
+      tryMove: jest.fn(),
+    } as unknown as MoveExecutor;
+
+    let renderer!: TestRenderer.ReactTestRenderer;
+    act(() => {
+      renderer = TestRenderer.create(
+        <AccessibilityLayer
+          chess={chess}
+          boardState={boardState}
+          config={config}
+          moveExecutor={moveExecutor}
+        />
+      );
+    });
+    const root = renderer.root;
+
+    expect(findByLabel(root, 'e2, white pawn')).toHaveLength(1);
+    expect(findByLabel(root, 'e1, white king')).toHaveLength(1);
+    expect(findByLabel(root, 'd8, black queen')).toHaveLength(1);
+    expect(findByLabel(root, 'e4, empty')).toHaveLength(1);
+    expect(findByLabel(root, 'Chessboard, white to move')).toHaveLength(1);
+  });
+
+  it('selects an own piece when its square is activated', () => {
+    const chess = new Chess();
+    const boardState = makeBoardState(chess);
+    const selectPiece = jest.fn();
+    const moveExecutor = {
+      selectPiece,
+      tryMove: jest.fn(),
+    } as unknown as MoveExecutor;
+
+    let renderer!: TestRenderer.ReactTestRenderer;
+    act(() => {
+      renderer = TestRenderer.create(
+        <AccessibilityLayer
+          chess={chess}
+          boardState={boardState}
+          config={config}
+          moveExecutor={moveExecutor}
+        />
+      );
+    });
+
+    const [e2] = findByLabel(renderer.root, 'e2, white pawn');
+    act(() => {
+      (e2.props as { onAccessibilityTap: () => void }).onAccessibilityTap();
+    });
+    expect(selectPiece).toHaveBeenCalledWith('e2');
+  });
+
+  it('positions squares using the board geometry', () => {
+    const chess = new Chess();
+    const boardState = makeBoardState(chess);
+    let renderer!: TestRenderer.ReactTestRenderer;
+    act(() => {
+      renderer = TestRenderer.create(
+        <AccessibilityLayer
+          chess={chess}
+          boardState={boardState}
+          config={config}
+          moveExecutor={
+            {
+              selectPiece: jest.fn(),
+              tryMove: jest.fn(),
+            } as unknown as MoveExecutor
+          }
+        />
+      );
+    });
+    const [e1] = findByLabel(renderer.root, 'e1, white king');
+    const pos = squareToPosition('e1' as Square, 50, false);
+    const style = (e1.props as { style: Array<Record<string, number>> }).style;
+    const flat = Object.assign({}, ...style);
+    expect(flat.left).toBe(pos.x);
+    expect(flat.top).toBe(pos.y);
+  });
+});

--- a/src/components/accessibility-layer.tsx
+++ b/src/components/accessibility-layer.tsx
@@ -1,0 +1,138 @@
+import React, { useCallback, useReducer } from 'react';
+import { StyleSheet, View } from 'react-native';
+import type { Chess, Square } from 'chess.js';
+import { useAnimatedReaction, runOnJS } from 'react-native-reanimated';
+
+import type { BoardConfig, BoardState } from '../state/types';
+import { SQUARES } from '../state/types';
+import { squareToPosition } from '../state/use-board-state';
+import type { MoveExecutor } from '../state/move-executor';
+
+const COLOR_NAME: Record<'w' | 'b', string> = { w: 'white', b: 'black' };
+const PIECE_NAME: Record<string, string> = {
+  p: 'pawn',
+  n: 'knight',
+  b: 'bishop',
+  r: 'rook',
+  q: 'queen',
+  k: 'king',
+};
+
+const describeSquare = (chess: Chess, square: Square): string => {
+  const piece = chess.get(square);
+  if (!piece) return `${square}, empty`;
+  return `${square}, ${COLOR_NAME[piece.color]} ${PIECE_NAME[piece.type]}`;
+};
+
+interface AccessibilityLayerProps {
+  chess: Chess;
+  boardState: BoardState;
+  config: BoardConfig;
+  moveExecutor: MoveExecutor;
+}
+
+/**
+ * Transparent overlay that makes the Skia-rendered board usable by screen
+ * readers. Each square is an accessible button labelled with its contents
+ * (e.g. "e4, white pawn"); activating one runs the same select / move flow as
+ * a tap. `pointerEvents="none"` keeps sighted drag & tap flowing through to the
+ * canvas underneath — VoiceOver/TalkBack still activate via the a11y tree.
+ */
+export const AccessibilityLayer: React.FC<AccessibilityLayerProps> = ({
+  chess,
+  boardState,
+  config,
+  moveExecutor,
+}) => {
+  const { pieceSize, flipped } = config;
+
+  // The board lives in SharedValues (UI thread); labels are React props, so
+  // mirror "something changed" into a render tick. turn + lastMove move on
+  // essentially every mutation (play, undo, reset, fen load).
+  const [, bump] = useReducer((n: number) => n + 1, 0);
+  useAnimatedReaction(
+    () => {
+      const lm = boardState.lastMove.get();
+      return `${boardState.turn.get()}:${lm ? `${lm.from}${lm.to}` : ''}`;
+    },
+    (curr, prev) => {
+      if (prev !== null && curr !== prev) runOnJS(bump)();
+    }
+  );
+
+  // Mirror of the tap state machine (use-board-gesture), run on the JS thread
+  // from an accessibility activation.
+  const activate = useCallback(
+    (square: Square) => {
+      const selected = boardState.selectedSquare.get();
+      const piece = boardState.squares[square].piece.get();
+      const turn = boardState.turn.get();
+      const isOwnPiece = !!piece && piece[0] === turn;
+
+      if (!selected) {
+        if (isOwnPiece) moveExecutor.selectPiece(square);
+        return;
+      }
+      if (square === selected) {
+        boardState.selectedSquare.set(null);
+        boardState.validMoves.set([]);
+        return;
+      }
+      if (boardState.validMoves.get().includes(square)) {
+        moveExecutor.tryMove(selected, square);
+        return;
+      }
+      if (isOwnPiece) {
+        moveExecutor.selectPiece(square);
+        return;
+      }
+      boardState.selectedSquare.set(null);
+      boardState.validMoves.set([]);
+    },
+    [boardState, moveExecutor]
+  );
+
+  const selectedSquare = boardState.selectedSquare.get();
+
+  return (
+    <View
+      style={StyleSheet.absoluteFill}
+      pointerEvents="box-none"
+      accessibilityLabel={`Chessboard, ${
+        COLOR_NAME[boardState.turn.get()]
+      } to move`}
+    >
+      {SQUARES.map((square) => {
+        const pos = squareToPosition(square, pieceSize, flipped);
+        return (
+          <View
+            key={square}
+            // none → sighted touches fall through to the Skia canvas; VoiceOver
+            // still activates via onAccessibilityTap.
+            pointerEvents="none"
+            accessible
+            accessibilityRole="button"
+            accessibilityLabel={describeSquare(chess, square)}
+            accessibilityState={{ selected: square === selectedSquare }}
+            onAccessibilityTap={() => activate(square)}
+            style={[
+              styles.square,
+              {
+                left: pos.x,
+                top: pos.y,
+                width: pieceSize,
+                height: pieceSize,
+              },
+            ]}
+          />
+        );
+      })}
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  square: {
+    position: 'absolute',
+  },
+});

--- a/src/components/promotion-dialog.tsx
+++ b/src/components/promotion-dialog.tsx
@@ -12,6 +12,12 @@ import type { BoardConfig } from '../state';
 import { PIECE_SOURCES } from '../assets/piece-images';
 
 const PROMOTION_PIECES: PieceSymbol[] = ['q', 'r', 'b', 'n'];
+const PROMOTION_NAME: Record<string, string> = {
+  q: 'queen',
+  r: 'rook',
+  b: 'bishop',
+  n: 'knight',
+};
 
 interface PromotionDialogProps {
   color: 'w' | 'b';
@@ -55,7 +61,12 @@ export const PromotionDialog: React.FC<PromotionDialogProps> = React.memo(
 
     return (
       <Modal transparent visible animationType="fade" onRequestClose={onCancel}>
-        <Pressable style={styles.overlay} onPress={onCancel}>
+        <Pressable
+          style={styles.overlay}
+          onPress={onCancel}
+          accessibilityRole="button"
+          accessibilityLabel="Cancel promotion"
+        >
           <Animated.View
             entering={FadeIn.duration(200)}
             exiting={FadeOut.duration(200)}
@@ -75,6 +86,8 @@ export const PromotionDialog: React.FC<PromotionDialogProps> = React.memo(
                   ]}
                   onPress={() => onSelect(piece)}
                   activeOpacity={0.7}
+                  accessibilityRole="button"
+                  accessibilityLabel={`Promote to ${PROMOTION_NAME[piece]}`}
                 >
                   <Image source={source} style={styles.pieceImage} />
                 </TouchableOpacity>

--- a/src/components/skia/gesture-board.tsx
+++ b/src/components/skia/gesture-board.tsx
@@ -33,6 +33,7 @@ import { usePieceSpriteSheet } from '../../assets/piece-images';
 import { findKingSquare } from '../../helpers/find-king-square';
 import { SkiaBoard } from './skia-board';
 import { PromotionDialog } from '../promotion-dialog';
+import { AccessibilityLayer } from '../accessibility-layer';
 import type { EffectParams, EffectTrigger } from '../../types';
 
 const styles = StyleSheet.create({
@@ -246,6 +247,12 @@ export const GestureBoard = forwardRef<ChessboardRef, GestureBoardProps>(
             />
           </View>
         </GestureDetector>
+        <AccessibilityLayer
+          chess={chess}
+          boardState={boardState}
+          config={config}
+          moveExecutor={moveExecutor}
+        />
         {showPromotion && promotionInfoRef.current && (
           <PromotionDialog
             color={promotionInfoRef.current.color}


### PR DESCRIPTION
## Why
The board renders through a Skia `Canvas`, so it was **invisible to screen readers** — VoiceOver/TalkBack users couldn't perceive the position, whose turn it is, or make a move. The promotion picker's buttons were unlabeled too.

## What
- **`AccessibilityLayer`** — a transparent overlay of 64 accessible square buttons, each labelled with its contents (`"e4, white pawn"` / `"d5, empty"`) and a board-level `"Chessboard, white to move"` label. Activating a square runs the same select / move flow as a tap (mirrors the tap state machine). `pointerEvents="none"` keeps sighted drag & tap flowing to the canvas; VoiceOver/TalkBack still activate via the accessibility tree. Labels refresh from a `turn`/`lastMove` reaction.
- **Promotion dialog** — `accessibilityRole="button"` + labels on each piece (`"Promote to queen"` …) and the cancel backdrop.
- Added `useAnimatedReaction` to the reanimated test mock (it was missing).

Additive — no public API change.

## Tests
New `accessibility-layer.test.tsx`: square labels, activation calls select, geometry. Suite: 237 passing. lint + tsc clean.

Draft — not for merge yet; runtime VoiceOver/TalkBack pass still to do.

🤖 Generated with [Claude Code](https://claude.com/claude-code)