### PR TITLE
chore: add GitHub Sponsors funding config

### DIFF
--- a/.github/FUNDING.yml
+++ b/.github/FUNDING.yml
@@ -1,0 +1,4 @@
+# These are supported funding model platforms
+
+github: enzomanuelmangano
+custom: ['https://reactiive.io/demos', 'https://reanimate.dev']


### PR DESCRIPTION
Adds `.github/FUNDING.yml` to enable the repo **Sponsor** button — mirrors the config on the `ennio` repo.

```yml
github: enzomanuelmangano
custom: ['https://reactiive.io/demos', 'https://reanimate.dev']
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)