### PR TITLE
refactor!: remove dead durations prop + truthful peer deps

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,10 +20,12 @@ A high-performing, zero-render chessboard for React Native built with Skia and R
 
 **Required peer dependencies:**
 
-- [react-native-reanimated (>= 3.6.0)](https://docs.swmansion.com/react-native-reanimated/docs)
+- [react-native-reanimated (>= 4.0.0)](https://docs.swmansion.com/react-native-reanimated/docs)
 - [react-native-gesture-handler (>= 2.14.0)](https://docs.swmansion.com/react-native-gesture-handler/docs/)
-- [@shopify/react-native-skia (>= 1.0.0)](https://shopify.github.io/react-native-skia/)
-- [react-native-worklets (>= 0.3.0)](https://docs.swmansion.com/react-native-worklets/docs/)
+- [@shopify/react-native-skia (>= 2.0.0)](https://shopify.github.io/react-native-skia/)
+- [react-native-worklets (>= 0.7.0)](https://docs.swmansion.com/react-native-worklets/docs/)
+
+Requires React Native 0.79+ (New Architecture) and React 19 — the floors set by Skia 2 and Reanimated 4.
 
 ```sh
 bun add react-native-chessboard
@@ -313,8 +315,8 @@ Returns the current state of the chessboard.
 
 ### Breaking Changes
 
-1. **New peer dependency**: `@shopify/react-native-skia >= 1.0.0`
-2. **Minimum versions**: React Native 0.71+, Reanimated 3.6+
+1. **New peer dependencies**: `@shopify/react-native-skia >= 2.0.0`, `react-native-worklets >= 0.7.0`
+2. **Minimum versions**: React Native 0.79+ (New Architecture), React 19, Reanimated 4+
 3. **State API changes** (chess.js v1.0):
 
    - `in_check` → `isCheck`

--- a/package.json
+++ b/package.json
@@ -79,12 +79,12 @@
     "typescript": "~5.9.2"
   },
   "peerDependencies": {
-    "@shopify/react-native-skia": ">= 1.0.0",
-    "react": ">= 18.0.0",
-    "react-native": ">= 0.71.0",
+    "@shopify/react-native-skia": ">= 2.0.0",
+    "react": ">= 19.0.0",
+    "react-native": ">= 0.79.0",
     "react-native-gesture-handler": ">= 2.14.0",
-    "react-native-reanimated": ">= 3.6.0",
-    "react-native-worklets": ">= 0.3.0"
+    "react-native-reanimated": ">= 4.0.0",
+    "react-native-worklets": ">= 0.7.0"
   },
   "resolutions": {
     "@types/react": "19.2.10"

--- a/src/__tests__/board-background.test.tsx
+++ b/src/__tests__/board-background.test.tsx
@@ -25,7 +25,6 @@ const baseConfig = (overrides: Partial<BoardConfig> = {}): BoardConfig => ({
     checkmateHighlight: '#E84855',
     promotionPieceButton: '#FF9B71',
   },
-  durations: { move: 150 },
   animations: {
     move: MOVE_SPRING,
     scale: SCALE_SPRING,

--- a/src/__tests__/move-executor.test.ts
+++ b/src/__tests__/move-executor.test.ts
@@ -82,7 +82,6 @@ describe('createMoveExecutor', () => {
       checkmateHighlight: 'rgba(255, 0, 0, 0.4)',
       promotionPieceButton: 'rgba(255, 255, 255, 0.8)',
     },
-    durations: { move: 200 },
     animations: {
       move: MOVE_SPRING,
       scale: SCALE_SPRING,

--- a/src/__tests__/promotion-cancel.test.ts
+++ b/src/__tests__/promotion-cancel.test.ts
@@ -79,7 +79,6 @@ const config: BoardConfig = {
     checkmateHighlight: '#E84855',
     promotionPieceButton: '#FF9B71',
   },
-  durations: { move: 150 },
   animations: {
     move: MOVE_SPRING,
     scale: SCALE_SPRING,

--- a/src/__tests__/render-effect-reset.test.ts
+++ b/src/__tests__/render-effect-reset.test.ts
@@ -78,7 +78,6 @@ const config: BoardConfig = {
     checkmateHighlight: '#E84855',
     promotionPieceButton: '#FF9B71',
   },
-  durations: { move: 150 },
   animations: {
     move: MOVE_SPRING,
     scale: SCALE_SPRING,

--- a/src/__tests__/use-chessboard-ref.test.ts
+++ b/src/__tests__/use-chessboard-ref.test.ts
@@ -82,7 +82,6 @@ const config = {
     checkmateHighlight: 'rgba(255, 0, 0, 0.4)',
     promotionPieceButton: 'rgba(255, 255, 255, 0.8)',
   },
-  durations: { move: 200 },
   animations: {
     move: MOVE_SPRING,
     scale: SCALE_SPRING,

--- a/src/index.tsx
+++ b/src/index.tsx
@@ -38,7 +38,6 @@ const Chessboard = forwardRef<ChessboardRef, ChessboardProps>(
       withLetters,
       withNumbers,
       colors,
-      durations,
       onMove,
       onIllegalMove,
       renderEffect,
@@ -56,7 +55,6 @@ const Chessboard = forwardRef<ChessboardRef, ChessboardProps>(
         withLetters={withLetters}
         withNumbers={withNumbers}
         colors={colors}
-        durations={durations}
         fontSource={fontSource}
       >
         <GestureBoard

--- a/src/state/board-state-context.tsx
+++ b/src/state/board-state-context.tsx
@@ -30,7 +30,6 @@ export type BoardStateProviderProps = {
   withLetters?: boolean;
   withNumbers?: boolean;
   colors?: Partial<BoardConfig['colors']>;
-  durations?: Partial<BoardConfig['durations']>;
   fontSource?: ImageSourcePropType;
 };
 
@@ -40,10 +39,6 @@ const defaultColors: BoardConfig['colors'] = {
   lastMoveHighlight: 'rgba(255,255,0, 0.5)',
   checkmateHighlight: '#E84855',
   promotionPieceButton: '#FF9B71',
-};
-
-const defaultDurations: BoardConfig['durations'] = {
-  move: 150,
 };
 
 const defaultAnimations: BoardConfig['animations'] = {
@@ -61,7 +56,6 @@ export const BoardStateProvider: React.FC<BoardStateProviderProps> = ({
   withLetters = true,
   withNumbers = true,
   colors,
-  durations,
   fontSource,
 }) => {
   const pieceSize = boardSize / 8;
@@ -75,7 +69,6 @@ export const BoardStateProvider: React.FC<BoardStateProviderProps> = ({
       withLetters,
       withNumbers,
       colors: { ...defaultColors, ...colors },
-      durations: { ...defaultDurations, ...durations },
       animations: defaultAnimations,
       fontSource: fontSource ?? null,
     }),
@@ -87,7 +80,6 @@ export const BoardStateProvider: React.FC<BoardStateProviderProps> = ({
       withLetters,
       withNumbers,
       colors,
-      durations,
       fontSource,
     ]
   );

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -59,9 +59,6 @@ export interface BoardConfig {
     checkmateHighlight: string;
     promotionPieceButton: string;
   };
-  durations: {
-    move: number;
-  };
   animations: {
     move: WithSpringConfig;
     scale: WithSpringConfig;


### PR DESCRIPTION
## Why
Two places where the package advertises an API/compatibility surface it doesn't deliver:

1. `durations={{ move }}` stopped doing anything in the v2 spring rewrite — accepted, merged into `BoardConfig`, read nowhere (#14 reported it broken; README dropped it in 5554041).
2. Peer ranges (`reanimated >= 3.6`, `skia >= 1.0`, `RN >= 0.71`) predate the code as shipped: `energyThreshold` is Reanimated-4-only, `scheduleOnRN` needs standalone `react-native-worklets` (>= 0.7, which Reanimated 4.2 itself requires), and Skia 2 sets the RN 0.79 / React 19 floor.

## What
- drop `durations` from `ChessboardProps` pass-through, `BoardStateProviderProps`, defaults, `BoardConfig`, test fixtures
- peers: `skia >= 2.0.0`, `reanimated >= 4.0.0`, `worklets >= 0.7.0`, `react >= 19`, `react-native >= 0.79`
- README: installation + migration sections match

**BREAKING**: removed prop type + raised peer floors → next release should be **0.3.0**.

## Test plan
- `bun run ci` green (lint, typecheck, format, 237 tests)

🤖 Generated with [Claude Code](https://claude.com/claude-code)