### PR TITLE
chore(example): let bun run the Skia postinstall

### DIFF
--- a/example/bun.lock
+++ b/example/bun.lock
@@ -29,6 +29,9 @@
       },
     },
   },
+  "trustedDependencies": [
+    "@shopify/react-native-skia",
+  ],
   "packages": {
     "@babel/code-frame": ["@babel/code-frame@7.29.0", "", { "dependencies": { "@babel/helper-validator-identifier": "^7.28.5", "js-tokens": "^4.0.0", "picocolors": "^1.1.1" } }, "sha512-9NhCeYjq9+3uxgdtp20LSiJXJvN0FeCtNGpJxuMFZ1Kv3cWUNb6DOhJwUvcVCzKGR66cw4njwM6hrJLqgOwbcw=="],
 

--- a/example/package.json
+++ b/example/package.json
@@ -31,5 +31,8 @@
     "babel-plugin-module-resolver": "^5.0.3",
     "typescript": "~5.9.2"
   },
-  "private": true
+  "private": true,
+  "trustedDependencies": [
+    "@shopify/react-native-skia"
+  ]
 }


### PR DESCRIPTION
## Problem

A fresh clone + `bun install` in `example/` leaves `@shopify/react-native-skia/libs/` empty, so `bunx expo run:ios` dies during pod install:

```
[!] Invalid `react-native-skia.podspec` file:
    Skia prebuilt binaries not found. Please run the postinstall script.
```

Bun does not run dependency lifecycle scripts unless the package is listed in `trustedDependencies`. Skia ships its prebuilt binaries via `postinstall` (`node ./scripts/install-skia.mjs`), so that script never ran.

## Fix

Add `@shopify/react-native-skia` to `example/package.json` → `trustedDependencies`, and commit the resulting `example/bun.lock` update.

## Verification

Ran the postinstall manually to confirm it is the only missing step — `libs/apple/ios` and `libs/android/*` populate, and the example then builds and runs. Also verified the example runs in Expo Go (Skia is bundled there), which is the faster loop and needs no pod install at all.

Only touches the example app; library sources and the published package are unaffected.

🤖 Generated with [Claude Code](https://claude.com/claude-code)