### PR TITLE
fix: keep the captured piece drawn until the mover lands

### DIFF
--- a/src/__tests__/move-executor.test.ts
+++ b/src/__tests__/move-executor.test.ts
@@ -1,6 +1,7 @@
 import { Chess, Square } from 'chess.js';
 import { createMoveExecutor } from '../state/move-executor';
 import { makeMutable } from 'react-native-reanimated';
+import * as Reanimated from 'react-native-reanimated';
 import type {
   BoardState,
   PieceCode,
@@ -221,6 +222,71 @@ describe('createMoveExecutor', () => {
 
       expect(move).toBeTruthy();
       expect(move?.san).toBe('O-O-O');
+    });
+  });
+
+  describe('capture timing', () => {
+    // The shared mock settles every spring synchronously, which hides the
+    // window this behaviour is about. Hold the settle callbacks instead so
+    // the in-flight frames are observable.
+    const holdSprings = () => {
+      const settles: Array<(finished?: boolean) => void> = [];
+      const spy = jest.spyOn(Reanimated, 'withSpring').mockImplementation(((
+        toValue: unknown,
+        _config?: unknown,
+        callback?: (finished?: boolean) => void
+      ) => {
+        if (callback) settles.push(callback);
+        return toValue;
+      }) as typeof Reanimated.withSpring);
+      return { settles, spy };
+    };
+
+    it('keeps the captured piece drawn until the mover lands', () => {
+      const chess = new Chess();
+      chess.move('e4');
+      chess.move('d5');
+
+      const boardState = createMockBoardState(chess, PIECE_SIZE);
+      const executor = createMoveExecutor(chess, boardState, config, {});
+      const { settles, spy } = holdSprings();
+
+      try {
+        executor.executeMove('e4' as Square, 'd5' as Square);
+
+        // Mid-flight: the black pawn still occupies d5, with the white pawn
+        // riding above it.
+        expect(boardState.squares.d5.piece.get()).toBe('bp');
+        expect(boardState.squares.e4.zIndex.get()).toBe(100);
+
+        settles.forEach((settle) => settle(true));
+
+        expect(boardState.squares.d5.piece.get()).toBe('wp');
+        expect(boardState.squares.e4.piece.get()).toBeNull();
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('leaves the captured piece in place when the spring is cancelled', () => {
+      const chess = new Chess();
+      chess.move('e4');
+      chess.move('d5');
+
+      const boardState = createMockBoardState(chess, PIECE_SIZE);
+      const executor = createMoveExecutor(chess, boardState, config, {});
+      const { settles, spy } = holdSprings();
+
+      try {
+        executor.executeMove('e4' as Square, 'd5' as Square);
+        // A cancelled spring means someone else (resetBoard, a newer move)
+        // now owns these squares — the executor must not write to them.
+        settles.forEach((settle) => settle(false));
+
+        expect(boardState.squares.d5.piece.get()).toBe('bp');
+      } finally {
+        spy.mockRestore();
+      }
     });
   });
 

--- a/src/state/move-executor.ts
+++ b/src/state/move-executor.ts
@@ -106,10 +106,13 @@ export const createMoveExecutor = (
     const toState = boardState.squares[to];
     const movingPiece = fromState.piece.get();
 
-    // Handle capture - clear target square piece
-    if (move.captured) {
-      toState.piece.set(null);
-    }
+    // A captured piece is deliberately NOT cleared here. The mover is raised
+    // to zIndex 100 below and `commitMove` overwrites the target square's
+    // sprite on the exact frame the spring settles, so the capture reads as
+    // the piece being taken rather than vanishing early. Clearing up-front
+    // left the destination empty for the whole flight on tap moves, and on
+    // drag-drops the one-JS-tick gap between the UI-thread drop and this call
+    // showed both pieces side by side before the captured one popped away.
 
     // Animate the piece
     const toPos = squareToPosition(to, pieceSize, flipped);


### PR DESCRIPTION
## Problem

`executeMove` cleared the destination square as soon as chess.js reported a capture:

```ts
// Handle capture - clear target square piece
if (move.captured) {
  toState.piece.set(null);
}
```

That runs before the moving piece has travelled anywhere, so:

- **Tap moves** — the destination is empty for the whole flight. The captured piece disappears a beat before it is actually taken.
- **Drag-drops** — the drop happens on the UI thread and this call lands one JS tick later, so both pieces are visible side by side, then the captured one pops out of existence.

## Fix

Drop the eager clear. It was never needed:

- the mover is raised to `zIndex 100`, so it already draws above whatever occupies the destination;
- `commitMove` writes `toState.piece` on the exact frame the spring settles.

Removing the clear makes the swap atomic — the captured sprite is replaced by the moving one in a single frame.

Cancellation semantics are unchanged: `commitMove` only writes when `finished` is true, so a `resetBoard` or a newer animation that cancels this spring still owns the square. That is now asserted explicitly.

En passant is untouched — that captured pawn is not on the destination square and is still cleared by the dedicated `flags.includes('e')` branch.

## Tests

The shared reanimated mock settles every spring synchronously, which is exactly why the existing suite could not see this window. The new `capture timing` block holds the settle callbacks so the in-flight frames are observable:

- captured piece is still on the destination mid-flight, with the mover at `zIndex 100`, and is replaced on settle
- a cancelled spring (`finished === false`) leaves the destination untouched

Verified both fail on `main` and pass with the fix. Full suite: 239 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)