### PR TITLE
fix: track drag state separately from zIndex

### DIFF
--- a/src/__mocks__/react-native-gesture-handler.ts
+++ b/src/__mocks__/react-native-gesture-handler.ts
@@ -13,7 +13,9 @@ type GestureCallback = (event: MockGestureEvent) => void;
 
 class MockPanGesture {
   private _enabled = true;
+  private _minDistance = 0;
   private _onBegin?: GestureCallback;
+  private _onStart?: GestureCallback;
   private _onUpdate?: GestureCallback;
   private _onEnd?: GestureCallback;
   private _onFinalize?: GestureCallback;
@@ -23,8 +25,18 @@ class MockPanGesture {
     return this;
   }
 
+  minDistance(value: number) {
+    this._minDistance = value;
+    return this;
+  }
+
   onBegin(callback: GestureCallback) {
     this._onBegin = callback;
+    return this;
+  }
+
+  onStart(callback: GestureCallback) {
+    this._onStart = callback;
     return this;
   }
 
@@ -50,6 +62,14 @@ class MockPanGesture {
     }
   }
 
+  // Fires the handler the real gesture only runs once `minDistance` has been
+  // exceeded — i.e. the pan has actually become a drag.
+  simulateStart(event: MockGestureEvent) {
+    if (this._enabled && this._onStart) {
+      this._onStart(event);
+    }
+  }
+
   simulateUpdate(event: MockGestureEvent) {
     if (this._enabled && this._onUpdate) {
       this._onUpdate(event);
@@ -70,6 +90,10 @@ class MockPanGesture {
 
   isEnabled() {
     return this._enabled;
+  }
+
+  getMinDistance() {
+    return this._minDistance;
   }
 }
 

--- a/src/__tests__/drag-lifecycle.test.tsx
+++ b/src/__tests__/drag-lifecycle.test.tsx
@@ -1,0 +1,198 @@
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import { Chess, Square } from 'chess.js';
+import { makeMutable } from 'react-native-reanimated';
+// Types come from the mock directly: `moduleNameMapper` only rewrites the
+// runtime resolution, so `react-native-gesture-handler` still types to the
+// real package.
+import type { MockPanGesture } from '../__mocks__/react-native-gesture-handler';
+import { useBoardGesture } from '../hooks/use-board-gesture';
+import { squareToPosition } from '../state/use-board-state';
+import type { MoveExecutor } from '../state/move-executor';
+import type {
+  BoardState,
+  BoardConfig,
+  PieceCode,
+  SquareState,
+  HighlightState,
+} from '../state/types';
+import { SQUARES } from '../state/types';
+import {
+  MOVE_SPRING,
+  SCALE_SPRING,
+  SNAP_BACK_SPRING,
+} from '../config/animations';
+
+// react-test-renderer refuses to treat `act` as concurrent-safe without this.
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+const PIECE_SIZE = 50;
+
+const createMockBoardState = (chess: Chess): BoardState => {
+  const squares: Partial<Record<Square, SquareState>> = {};
+  const highlights: Partial<Record<Square, HighlightState>> = {};
+
+  for (const square of SQUARES) {
+    const { x, y } = squareToPosition(square, PIECE_SIZE, false);
+    const piece = chess.get(square);
+    squares[square] = {
+      piece: makeMutable<PieceCode>(
+        piece ? (`${piece.color}${piece.type}` as PieceCode) : null
+      ),
+      translateX: makeMutable(x),
+      translateY: makeMutable(y),
+      scale: makeMutable(1),
+      zIndex: makeMutable(0),
+      lastMove: makeMutable(false),
+      inCheck: makeMutable(false),
+    };
+    highlights[square] = { color: makeMutable<string | null>(null) };
+  }
+
+  return {
+    squares: squares as Record<Square, SquareState>,
+    highlights: highlights as Record<Square, HighlightState>,
+    turn: makeMutable(chess.turn()),
+    selectedSquare: makeMutable<Square | null>(null),
+    validMoves: makeMutable<Square[]>([]),
+    lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
+    isCheck: makeMutable(false),
+    kingInCheckSquare: makeMutable<Square | null>(null),
+  };
+};
+
+const config: BoardConfig = {
+  boardSize: PIECE_SIZE * 8,
+  pieceSize: PIECE_SIZE,
+  gestureEnabled: true,
+  flipped: false,
+  withLetters: false,
+  withNumbers: false,
+  colors: {
+    white: '#f0d9b5',
+    black: '#b58863',
+    lastMoveHighlight: 'rgba(255, 255, 0, 0.4)',
+    checkmateHighlight: 'rgba(255, 0, 0, 0.4)',
+    promotionPieceButton: 'rgba(255, 255, 255, 0.8)',
+  },
+  animations: {
+    move: MOVE_SPRING,
+    scale: SCALE_SPRING,
+    snapBack: SNAP_BACK_SPRING,
+  },
+  fontSource: null,
+};
+
+const event = (x: number, y: number) => ({
+  x,
+  y,
+  translationX: 0,
+  translationY: 0,
+});
+
+/** Mounts the hook and hands back the pan gesture the board actually uses. */
+const mountGesture = (boardState: BoardState) => {
+  const moveExecutor = {
+    tryMove: jest.fn(),
+    selectPiece: jest.fn(),
+  } as unknown as MoveExecutor;
+
+  let pan: MockPanGesture | undefined;
+
+  const Probe = () => {
+    const gesture = useBoardGesture({
+      boardState,
+      config,
+      moveExecutor,
+      gestureEnabled: true,
+    }) as unknown as { gestures: [unknown, MockPanGesture] };
+    pan = gesture.gestures[1];
+    return null;
+  };
+
+  act(() => {
+    create(<Probe />);
+  });
+
+  if (!pan) throw new Error('pan gesture was not captured');
+  return { pan, moveExecutor };
+};
+
+describe('drag lifecycle', () => {
+  // e2 in an unflipped board: file e -> column 4, rank 2 -> row 6.
+  const E2 = 'e2' as Square;
+  const e2Origin = squareToPosition(E2, PIECE_SIZE, false);
+  const e2Center = {
+    x: e2Origin.x + PIECE_SIZE / 2,
+    y: e2Origin.y + PIECE_SIZE / 2,
+  };
+
+  it('still handles the drop when an animation zeroes zIndex mid-drag', () => {
+    const chess = new Chess();
+    const boardState = createMockBoardState(chess);
+    const { pan } = mountGesture(boardState);
+    const square = boardState.squares[E2];
+
+    pan.simulateBegin(event(e2Center.x, e2Center.y));
+    pan.simulateStart(event(e2Center.x, e2Center.y));
+    expect(square.zIndex.get()).toBe(100);
+
+    // Drag the pawn a long way up the board.
+    pan.simulateUpdate(event(e2Center.x, e2Center.y - PIECE_SIZE * 3));
+    expect(square.translateY.get()).not.toBe(e2Origin.y);
+
+    // A rollback spring belonging to an older animation gets cancelled and
+    // drops this square's zIndex back to 0 while the finger is still down.
+    square.zIndex.set(0);
+
+    pan.simulateEnd(event(e2Center.x, e2Center.y - PIECE_SIZE * 3));
+
+    // The drop must still be processed: no valid moves were published, so the
+    // piece snaps home rather than being stranded where the finger left it.
+    expect(square.translateX.get()).toBe(e2Origin.x);
+    expect(square.translateY.get()).toBe(e2Origin.y);
+    expect(square.scale.get()).toBe(1);
+  });
+
+  it('ignores a drop when the pan never became a drag', () => {
+    const chess = new Chess();
+    const boardState = createMockBoardState(chess);
+    const { pan } = mountGesture(boardState);
+    const square = boardState.squares[E2];
+
+    // A move animation from an earlier turn still owns this square.
+    square.zIndex.set(100);
+    square.translateY.set(e2Origin.y - PIECE_SIZE);
+
+    // Finger touches down but never crosses minDistance, so onStart never
+    // fires and this is a tap, not a drag.
+    pan.simulateBegin(event(e2Center.x, e2Center.y));
+    pan.simulateEnd(event(e2Center.x, e2Center.y));
+
+    // The in-flight animation is left alone.
+    expect(square.zIndex.get()).toBe(100);
+    expect(square.translateY.get()).toBe(e2Origin.y - PIECE_SIZE);
+  });
+
+  it('clears the drag flag so the next touch starts clean', () => {
+    const chess = new Chess();
+    const boardState = createMockBoardState(chess);
+    const { pan } = mountGesture(boardState);
+    const square = boardState.squares[E2];
+
+    pan.simulateBegin(event(e2Center.x, e2Center.y));
+    pan.simulateStart(event(e2Center.x, e2Center.y));
+    pan.simulateUpdate(event(e2Center.x, e2Center.y - PIECE_SIZE * 3));
+    pan.simulateEnd(event(e2Center.x, e2Center.y - PIECE_SIZE * 3));
+    pan.simulateFinalize(event(e2Center.x, e2Center.y - PIECE_SIZE * 3));
+
+    // Second touch is a tap; the previous drag must not leak into it.
+    square.zIndex.set(100);
+    pan.simulateBegin(event(e2Center.x, e2Center.y));
+    pan.simulateEnd(event(e2Center.x, e2Center.y));
+
+    expect(square.zIndex.get()).toBe(100);
+  });
+});

--- a/src/hooks/use-board-gesture.ts
+++ b/src/hooks/use-board-gesture.ts
@@ -26,6 +26,10 @@ export const useBoardGesture = ({
 
   // Track the currently dragged piece
   const draggedSquare = useSharedValue<Square | null>(null);
+  // Whether the pan actually crossed `minDistance` and became a drag. This
+  // has to be tracked explicitly: `zIndex` is shared with the move/reset
+  // animations, so it is not a reliable signal of who is holding the piece.
+  const dragStarted = useSharedValue(false);
   const dragStartX = useSharedValue(0);
   const dragStartY = useSharedValue(0);
   // Offset between touch point and piece position (to follow finger exactly)
@@ -62,6 +66,7 @@ export const useBoardGesture = ({
       .minDistance(5) // Require some movement before starting drag
       .onBegin((event) => {
         'worklet';
+        dragStarted.set(false);
         // Just prepare for potential drag - store touch info
         const { x, y } = event;
         const square = positionToSquare(x, y, pieceSize, flipped);
@@ -89,6 +94,8 @@ export const useBoardGesture = ({
         const squareState = boardState.squares[square];
         const piece = squareState.piece.get();
         const turn = boardState.turn.get();
+
+        dragStarted.set(true);
 
         // Raise and scale the piece
         squareState.zIndex.set(100);
@@ -123,8 +130,12 @@ export const useBoardGesture = ({
 
         const squareState = boardState.squares[square];
 
-        // Only process drop if piece was actually dragged (zIndex > 0)
-        const wasDragged = squareState.zIndex.get() > 0;
+        // Only process drop if the pan actually became a drag. `zIndex` used
+        // to stand in for this, but the move and reset animations write it
+        // too: a rollback spring cancelled mid-pan zeroes it and the live
+        // drag then looked like it never started, stranding the piece under
+        // the finger.
+        const wasDragged = dragStarted.get();
         if (!wasDragged) {
           draggedSquare.set(null);
           return;
@@ -150,6 +161,7 @@ export const useBoardGesture = ({
           // Clear any previous selection/valid moves
           boardState.selectedSquare.set(null);
           boardState.validMoves.set([]);
+          dragStarted.set(false);
           draggedSquare.set(null);
           return;
         }
@@ -176,6 +188,7 @@ export const useBoardGesture = ({
           squareState.translateY.set(withSpring(targetPos.y, animations.move));
           // Note: zIndex stays elevated during animation - move-executor resets it after completion
           scheduleOnRN(handleTryMove, square, targetSquare);
+          dragStarted.set(false);
           draggedSquare.set(null);
           return;
         }
@@ -195,6 +208,7 @@ export const useBoardGesture = ({
         if (targetSquare !== square) {
           scheduleOnRN(handleIllegalMove, square, targetSquare);
         }
+        dragStarted.set(false);
         draggedSquare.set(null);
       })
       .onFinalize(() => {
@@ -202,12 +216,15 @@ export const useBoardGesture = ({
         const square = draggedSquare.get();
         if (square) {
           const squareState = boardState.squares[square];
-          // Only reset if piece was actually dragged
-          if (squareState.zIndex.get() > 0) {
+          // Only reset if piece was actually dragged. Same reasoning as
+          // `onEnd`: reading `zIndex` here would clobber an animation that
+          // legitimately owns the square.
+          if (dragStarted.get()) {
             squareState.scale.set(withSpring(1, animations.scale));
             squareState.zIndex.set(0);
           }
         }
+        dragStarted.set(false);
         draggedSquare.set(null);
       });
 
@@ -263,6 +280,7 @@ export const useBoardGesture = ({
     pieceSize,
     flipped,
     draggedSquare,
+    dragStarted,
     dragStartX,
     dragStartY,
     touchOffsetX,


### PR DESCRIPTION
## Problem

The pan handlers decided whether a gesture had actually become a drag by reading the square's render state:

```ts
// Only process drop if piece was actually dragged (zIndex > 0)
const wasDragged = squareState.zIndex.get() > 0;
```

`zIndex` is not the gesture's to read. `executeMove` raises it to 100 for the moving piece and the move/reset springs put it back, so the gesture and the animation layer were sharing one flag with two different meanings. Both directions break:

- **Live drag misread as no-drag.** A rollback spring cancelled while the finger is still down zeroes `zIndex`. `onEnd` sees `wasDragged === false`, returns early — the piece stays wherever the finger left it, never snaps back, and stays scaled at 1.1.
- **Tap misread as drag.** A square whose move animation is still in flight has `zIndex === 100`, so a plain tap on it runs the whole drop path and resets the square out from under the running animation.

## Fix

Introduce an explicit `dragStarted` shared value:

- set to `false` in `onBegin`
- set to `true` in `onStart` — which only fires once `minDistance(5)` has been exceeded, i.e. the pan really is a drag
- cleared on every exit path in `onEnd` and in `onFinalize`

`onEnd` / `onFinalize` now read `dragStarted`, and `zIndex` goes back to being purely a render concern.

## Tests

`src/__mocks__/react-native-gesture-handler.ts` was missing `minDistance()` and `onStart()` — the two methods `useBoardGesture` actually calls. The real hook therefore could not be mounted in a test at all, which is why this path had zero coverage. Added both (plus `simulateStart`).

New `src/__tests__/drag-lifecycle.test.tsx` mounts the real hook and drives the real pan gesture:

- a drag whose `zIndex` is zeroed mid-flight still snaps back on drop
- a tap on a square with an in-flight animation leaves that animation untouched
- the flag is cleared after a completed drag, so the next touch starts clean

All three fail on `main` and pass with the fix. Full suite: 242 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)