### PR TITLE
perf: compare drawn fields instead of config identity

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -8,6 +8,7 @@ module.exports = {
     '^.+\\.tsx?$': 'ts-jest',
   },
   moduleNameMapper: {
+    '^react-native$': '<rootDir>/src/__mocks__/react-native.ts',
     '^react-native-reanimated$':
       '<rootDir>/src/__mocks__/react-native-reanimated.ts',
     '^react-native-gesture-handler$':

--- a/src/__mocks__/react-native-skia.ts
+++ b/src/__mocks__/react-native-skia.ts
@@ -68,6 +68,19 @@ export const Skia = {
   RuntimeEffect: {
     Make: () => null,
   },
+  Path: {
+    // Records the circles the dots layer adds so tests can assert on them.
+    Make: () => {
+      const circles: Array<{ x: number; y: number; radius: number }> = [];
+      return {
+        __mock: 'SkPath',
+        circles,
+        addCircle: (x: number, y: number, radius: number) => {
+          circles.push({ x, y, radius });
+        },
+      };
+    },
+  },
 };
 
 export default {

--- a/src/__mocks__/react-native.ts
+++ b/src/__mocks__/react-native.ts
@@ -1,0 +1,47 @@
+// Minimal stand-in for react-native.
+//
+// The real package ships Flow-typed ESM that jest cannot parse without the
+// react-native babel preset, so any module importing it (skia-board,
+// board-state-context, promotion-dialog) was untestable. Only the handful of
+// APIs this library actually touches are implemented.
+
+type Style = Record<string, unknown>;
+
+export const StyleSheet = {
+  create: <T extends Record<string, Style>>(styles: T): T => styles,
+  flatten: (style: unknown): Style => {
+    if (!style) return {};
+    if (Array.isArray(style)) {
+      return style.reduce<Style>(
+        (acc, entry) => ({ ...acc, ...StyleSheet.flatten(entry) }),
+        {}
+      );
+    }
+    return style as Style;
+  },
+  absoluteFill: {} as Style,
+  hairlineWidth: 1,
+};
+
+export const Dimensions = {
+  get: () => ({ width: 400, height: 800, scale: 2, fontScale: 1 }),
+  addEventListener: () => ({ remove: () => {} }),
+};
+
+export const Platform = {
+  OS: 'ios' as const,
+  select: <T>(specifics: {
+    ios?: T;
+    android?: T;
+    default?: T;
+  }): T | undefined => specifics.ios ?? specifics.default,
+};
+
+export const Image = {
+  resolveAssetSource: (source: unknown) =>
+    typeof source === 'number' ? { uri: `asset://${source}` } : source,
+};
+
+export const View = 'View';
+export const Text = 'Text';
+export const Pressable = 'Pressable';

--- a/src/__tests__/board-memoization.test.tsx
+++ b/src/__tests__/board-memoization.test.tsx
@@ -1,0 +1,263 @@
+import React from 'react';
+import { act, create } from 'react-test-renderer';
+import type { ReactTestRenderer } from 'react-test-renderer';
+import { Chess, Square } from 'chess.js';
+import { useFont } from '@shopify/react-native-skia';
+import { makeMutable } from 'react-native-reanimated';
+import { BoardBackground } from '../components/skia/board-background';
+import { SkiaBoard } from '../components/skia/skia-board';
+import { squareToPosition } from '../state/use-board-state';
+import type {
+  BoardConfig,
+  BoardState,
+  PieceCode,
+  SquareState,
+  HighlightState,
+} from '../state/types';
+import { SQUARES } from '../state/types';
+import {
+  MOVE_SPRING,
+  SCALE_SPRING,
+  SNAP_BACK_SPRING,
+} from '../config/animations';
+import { findAllByType } from './render-utils';
+import type { RenderedJSON } from './render-utils';
+
+(
+  globalThis as { IS_REACT_ACT_ENVIRONMENT?: boolean }
+).IS_REACT_ACT_ENVIRONMENT = true;
+
+// `BoardBackground` calls `useFont` on every render (it is not memoized
+// internally), so the mock's call count is a render counter for it — and, by
+// extension, for any parent that would re-render it.
+const useFontMock = useFont as jest.Mock;
+
+const PIECE_SIZE = 50;
+
+/** A fresh object each call, mirroring an inline `colors` prop upstream. */
+const makeConfig = (overrides: Partial<BoardConfig> = {}): BoardConfig => ({
+  boardSize: PIECE_SIZE * 8,
+  pieceSize: PIECE_SIZE,
+  gestureEnabled: true,
+  flipped: false,
+  withLetters: true,
+  withNumbers: true,
+  colors: {
+    white: '#fff',
+    black: '#000',
+    lastMoveHighlight: 'rgba(255,255,0,0.5)',
+    checkmateHighlight: '#E84855',
+    promotionPieceButton: '#FF9B71',
+  },
+  animations: {
+    move: MOVE_SPRING,
+    scale: SCALE_SPRING,
+    snapBack: SNAP_BACK_SPRING,
+  },
+  fontSource: null,
+  ...overrides,
+});
+
+const makeBoardState = (): BoardState => {
+  const chess = new Chess();
+  const squares: Partial<Record<Square, SquareState>> = {};
+  const highlights: Partial<Record<Square, HighlightState>> = {};
+
+  for (const square of SQUARES) {
+    const { x, y } = squareToPosition(square, PIECE_SIZE, false);
+    const piece = chess.get(square);
+    squares[square] = {
+      piece: makeMutable<PieceCode>(
+        piece ? (`${piece.color}${piece.type}` as PieceCode) : null
+      ),
+      translateX: makeMutable(x),
+      translateY: makeMutable(y),
+      scale: makeMutable(1),
+      zIndex: makeMutable(0),
+      lastMove: makeMutable(false),
+      inCheck: makeMutable(false),
+    };
+    highlights[square] = { color: makeMutable<string | null>(null) };
+  }
+
+  return {
+    squares: squares as Record<Square, SquareState>,
+    highlights: highlights as Record<Square, HighlightState>,
+    turn: makeMutable(chess.turn()),
+    selectedSquare: makeMutable<Square | null>(null),
+    validMoves: makeMutable<Square[]>([]),
+    lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
+    isCheck: makeMutable(false),
+    kingInCheckSquare: makeMutable<Square | null>(null),
+  };
+};
+
+/** Renders `element`, then re-renders with `next` and reports render counts. */
+const renderThenUpdate = (
+  element: React.ReactElement,
+  next: React.ReactElement
+) => {
+  let renderer: ReactTestRenderer | null = null;
+  useFontMock.mockClear();
+
+  act(() => {
+    renderer = create(element);
+  });
+  const afterMount = useFontMock.mock.calls.length;
+
+  act(() => {
+    renderer!.update(next);
+  });
+
+  return { afterMount, afterUpdate: useFontMock.mock.calls.length };
+};
+
+describe('BoardBackground memoization', () => {
+  it('does not re-render for a new config object with the same values', () => {
+    const { afterMount, afterUpdate } = renderThenUpdate(
+      <BoardBackground config={makeConfig()} />,
+      <BoardBackground config={makeConfig()} />
+    );
+
+    expect(afterMount).toBeGreaterThan(0);
+    expect(afterUpdate).toBe(afterMount);
+  });
+
+  it('re-renders when a drawn colour changes', () => {
+    const { afterMount, afterUpdate } = renderThenUpdate(
+      <BoardBackground config={makeConfig()} />,
+      <BoardBackground
+        config={makeConfig({
+          colors: { ...makeConfig().colors, white: '#123456' },
+        })}
+      />
+    );
+
+    expect(afterUpdate).toBeGreaterThan(afterMount);
+  });
+
+  it('re-renders when pieceSize changes', () => {
+    const { afterMount, afterUpdate } = renderThenUpdate(
+      <BoardBackground config={makeConfig()} />,
+      <BoardBackground config={makeConfig({ pieceSize: 64 })} />
+    );
+
+    expect(afterUpdate).toBeGreaterThan(afterMount);
+  });
+
+  it('re-renders on flip while coordinates are shown', () => {
+    const { afterMount, afterUpdate } = renderThenUpdate(
+      <BoardBackground config={makeConfig()} />,
+      <BoardBackground config={makeConfig({ flipped: true })} />
+    );
+
+    expect(afterUpdate).toBeGreaterThan(afterMount);
+  });
+
+  it('ignores a flip when no coordinates are drawn', () => {
+    const bare = { withLetters: false, withNumbers: false };
+    const { afterMount, afterUpdate } = renderThenUpdate(
+      <BoardBackground config={makeConfig(bare)} />,
+      <BoardBackground config={makeConfig({ ...bare, flipped: true })} />
+    );
+
+    // The checkerboard is symmetric, so flipping it changes nothing to draw.
+    expect(afterUpdate).toBe(afterMount);
+  });
+});
+
+describe('SkiaBoard memoization', () => {
+  it('does not re-render its subtree for an equal config object', () => {
+    const boardState = makeBoardState();
+    const { afterMount, afterUpdate } = renderThenUpdate(
+      <SkiaBoard
+        config={makeConfig()}
+        boardState={boardState}
+        spriteImage={null}
+      />,
+      <SkiaBoard
+        config={makeConfig()}
+        boardState={boardState}
+        spriteImage={null}
+      />
+    );
+
+    expect(afterMount).toBeGreaterThan(0);
+    expect(afterUpdate).toBe(afterMount);
+  });
+
+  it('re-renders when a drawn colour changes', () => {
+    const boardState = makeBoardState();
+    const { afterMount, afterUpdate } = renderThenUpdate(
+      <SkiaBoard
+        config={makeConfig()}
+        boardState={boardState}
+        spriteImage={null}
+      />,
+      <SkiaBoard
+        config={makeConfig({
+          colors: { ...makeConfig().colors, black: '#654321' },
+        })}
+        boardState={boardState}
+        spriteImage={null}
+      />
+    );
+
+    expect(afterUpdate).toBeGreaterThan(afterMount);
+  });
+
+  it('ignores config fields it never draws', () => {
+    const boardState = makeBoardState();
+    const { afterMount, afterUpdate } = renderThenUpdate(
+      <SkiaBoard
+        config={makeConfig()}
+        boardState={boardState}
+        spriteImage={null}
+      />,
+      <SkiaBoard
+        config={makeConfig({ gestureEnabled: false })}
+        boardState={boardState}
+        spriteImage={null}
+      />
+    );
+
+    // `gestureEnabled` reaches the gesture layer, never a Skia node.
+    expect(afterUpdate).toBe(afterMount);
+  });
+
+  it('re-renders when the sprite sheet arrives', () => {
+    const boardState = makeBoardState();
+    const config = makeConfig();
+    const sprite = { __mock: 'SkImage' } as never;
+
+    // The config is untouched here, so the background legitimately stays
+    // bailed out — assert on the atlas the sprite is actually handed to.
+    let renderer: ReactTestRenderer | null = null;
+    act(() => {
+      renderer = create(
+        <SkiaBoard config={config} boardState={boardState} spriteImage={null} />
+      );
+    });
+
+    const atlasImage = () => {
+      const tree = (renderer as unknown as ReactTestRenderer).toJSON();
+      const atlas = findAllByType(tree as RenderedJSON, 'skia-atlas')[0];
+      return (atlas?.props as { image?: unknown } | undefined)?.image;
+    };
+
+    // No sheet yet: the atlas renders nothing at all.
+    expect(atlasImage()).toBeUndefined();
+
+    act(() => {
+      renderer!.update(
+        <SkiaBoard
+          config={config}
+          boardState={boardState}
+          spriteImage={sprite}
+        />
+      );
+    });
+
+    expect(atlasImage()).toBe(sprite);
+  });
+});

--- a/src/components/skia/board-background.tsx
+++ b/src/components/skia/board-background.tsx
@@ -17,6 +17,40 @@ interface BoardBackgroundProps {
   config: BoardConfig;
 }
 
+/**
+ * `config` is rebuilt whenever a consumer passes an inline `colors` object, so
+ * the default shallow compare never bails out and all 64 squares are recreated
+ * on every parent render. Compare the fields this component actually draws
+ * instead.
+ *
+ * Anything read in the render body must be listed here — adding a new field to
+ * the drawing above without adding it below means the change will not repaint.
+ */
+const areBackgroundPropsEqual = (
+  previous: Readonly<BoardBackgroundProps>,
+  next: Readonly<BoardBackgroundProps>
+) => {
+  const previousConfig = previous.config;
+  const nextConfig = next.config;
+  // `flipped` only reorders the coordinate labels; the checkerboard itself is
+  // symmetric, so a board without labels does not care.
+  const rendersCoordinates =
+    previousConfig.withLetters ||
+    previousConfig.withNumbers ||
+    nextConfig.withLetters ||
+    nextConfig.withNumbers;
+
+  return (
+    previousConfig.pieceSize === nextConfig.pieceSize &&
+    previousConfig.withLetters === nextConfig.withLetters &&
+    previousConfig.withNumbers === nextConfig.withNumbers &&
+    previousConfig.fontSource === nextConfig.fontSource &&
+    previousConfig.colors.white === nextConfig.colors.white &&
+    previousConfig.colors.black === nextConfig.colors.black &&
+    (!rendersCoordinates || previousConfig.flipped === nextConfig.flipped)
+  );
+};
+
 export const BoardBackground: React.FC<BoardBackgroundProps> = React.memo(
   ({ config }) => {
     const { pieceSize, colors, flipped, withLetters, withNumbers, fontSource } =
@@ -100,7 +134,8 @@ export const BoardBackground: React.FC<BoardBackgroundProps> = React.memo(
         {labels}
       </Group>
     );
-  }
+  },
+  areBackgroundPropsEqual
 );
 
 BoardBackground.displayName = 'BoardBackground';

--- a/src/components/skia/skia-board.tsx
+++ b/src/components/skia/skia-board.tsx
@@ -24,6 +24,43 @@ interface SkiaBoardProps {
   effectParams?: EffectParams;
 }
 
+/**
+ * Same reasoning as `BoardBackground`: an inline `colors` prop rebuilds
+ * `config` every parent render, which would otherwise re-render the entire
+ * canvas subtree. Only the fields this tree draws participate — notably
+ * `gestureEnabled` and `animations` do not, since they never reach a Skia
+ * node.
+ *
+ * Keep in sync with what the subtree reads; a field added to the render path
+ * but not compared here will not repaint.
+ */
+const areVisualPropsEqual = (
+  previous: Readonly<SkiaBoardProps>,
+  next: Readonly<SkiaBoardProps>
+) => {
+  const previousConfig = previous.config;
+  const nextConfig = next.config;
+
+  return (
+    previous.boardState === next.boardState &&
+    previous.spriteImage === next.spriteImage &&
+    previous.renderEffect === next.renderEffect &&
+    previous.effectParams === next.effectParams &&
+    previousConfig.boardSize === nextConfig.boardSize &&
+    previousConfig.pieceSize === nextConfig.pieceSize &&
+    previousConfig.flipped === nextConfig.flipped &&
+    previousConfig.withLetters === nextConfig.withLetters &&
+    previousConfig.withNumbers === nextConfig.withNumbers &&
+    previousConfig.fontSource === nextConfig.fontSource &&
+    previousConfig.colors.white === nextConfig.colors.white &&
+    previousConfig.colors.black === nextConfig.colors.black &&
+    previousConfig.colors.lastMoveHighlight ===
+      nextConfig.colors.lastMoveHighlight &&
+    previousConfig.colors.checkmateHighlight ===
+      nextConfig.colors.checkmateHighlight
+  );
+};
+
 export const SkiaBoard: React.FC<SkiaBoardProps> = React.memo(
   ({ config, boardState, spriteImage, renderEffect, effectParams }) => {
     const { boardSize, pieceSize } = config;
@@ -62,7 +99,8 @@ export const SkiaBoard: React.FC<SkiaBoardProps> = React.memo(
         )}
       </Canvas>
     );
-  }
+  },
+  areVisualPropsEqual
 );
 
 SkiaBoard.displayName = 'SkiaBoard';


### PR DESCRIPTION
## Problem

`BoardStateProvider` memoizes `config`, but one of the `useMemo` deps is the raw `colors` prop:

```ts
const config = useMemo((): BoardConfig => ({ ..., colors: { ...defaultColors, ...colors } }),
  [boardSize, pieceSize, gestureEnabled, flipped, withLetters, withNumbers, colors, fontSource]);
```

The idiomatic call site passes an object literal:

```tsx
<Chessboard colors={{ white: '#fff', black: '#000' }} />
```

That is a new reference on every parent render → `config` is rebuilt → the default shallow compare on `SkiaBoard` and `BoardBackground` never bails → the whole canvas subtree re-renders, including the 64 `<Rect>` elements `BoardBackground` builds in a nested loop. Nothing visible changed.

## Fix

Explicit comparators over the fields each component actually draws.

`SkiaBoard` compares `boardState` / `spriteImage` / `renderEffect` / `effectParams` by reference, plus the config fields that reach a Skia node. Deliberately excluded: `gestureEnabled` and `animations` — they reach the gesture and animation layers only. `colors.promotionPieceButton` likewise belongs to the promotion dialog.

`BoardBackground` compares `pieceSize`, `withLetters`, `withNumbers`, `fontSource`, `colors.white`, `colors.black` — and `flipped` **only when coordinates are drawn**, since the checkerboard itself is symmetric.

Both carry a comment that they must track what the render body reads: a drawn field left out of the comparator would silently fail to repaint. That is the real cost of hand-written comparators and it should be visible to the next person editing these files.

## Test infrastructure

`SkiaBoard` imports `StyleSheet` from `react-native`, whose Flow-typed ESM jest cannot parse — so the component had **zero** test coverage. This PR adds:

- `src/__mocks__/react-native.ts` — minimal `StyleSheet`, `Dimensions`, `Platform`, `Image`, mapped in `jest.config.js`. This also unblocks testing `board-state-context` and `promotion-dialog` later.
- `Skia.Path` in the skia mock, which `skia-dots` calls during render.

`useFont` runs on every `BoardBackground` render, so the mock's call count serves as a render counter.

`src/__tests__/board-memoization.test.tsx` asserts both directions — bail-outs *and* the repaints that must still happen:

| | |
|---|---|
| equal-valued new config object | no re-render |
| `colors.white` / `colors.black` changed | re-renders |
| `pieceSize` changed | re-renders |
| flip **with** coordinates | re-renders |
| flip **without** coordinates | no re-render |
| `gestureEnabled` changed | no re-render |
| sprite sheet arrives | atlas receives it |

4 of the 9 fail on `main`; the other 5 are over-memoization guards that must pass either way. Full suite: 251 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)