### PR TITLE
fix: apply fen resets in one UI-runtime transaction

### DIFF
--- a/jest.config.js
+++ b/jest.config.js
@@ -11,6 +11,8 @@ module.exports = {
     '^react-native$': '<rootDir>/src/__mocks__/react-native.ts',
     '^react-native-reanimated$':
       '<rootDir>/src/__mocks__/react-native-reanimated.ts',
+    '^react-native-worklets$':
+      '<rootDir>/src/__mocks__/react-native-worklets.ts',
     '^react-native-gesture-handler$':
       '<rootDir>/src/__mocks__/react-native-gesture-handler.ts',
     '^@shopify/react-native-skia$':

--- a/src/__mocks__/react-native-reanimated.ts
+++ b/src/__mocks__/react-native-reanimated.ts
@@ -1,4 +1,6 @@
 // Mock for react-native-reanimated
+import { useRef } from 'react';
+
 const createMockSharedValue = <T>(initialValue: T) => {
   let value = initialValue;
   return {
@@ -10,8 +12,17 @@ const createMockSharedValue = <T>(initialValue: T) => {
   };
 };
 
-export const useSharedValue = <T>(initialValue: T) =>
-  createMockSharedValue(initialValue);
+// The real hook returns the SAME mutable across renders. Returning a fresh
+// object here would make every shared value an unstable dependency, so effects
+// keyed on them would re-run every render in tests but not on device — hiding
+// exactly the class of bug those dependency arrays exist to prevent.
+export const useSharedValue = <T>(initialValue: T) => {
+  const ref = useRef<ReturnType<typeof createMockSharedValue<T>> | null>(null);
+  if (!ref.current) {
+    ref.current = createMockSharedValue(initialValue);
+  }
+  return ref.current;
+};
 
 export const makeMutable = <T>(initialValue: T) =>
   createMockSharedValue(initialValue);

--- a/src/__mocks__/react-native-worklets.ts
+++ b/src/__mocks__/react-native-worklets.ts
@@ -19,8 +19,20 @@ export const scheduleOnRuntime = <T extends (...args: any[]) => any>(
   fn(...args);
 };
 
+// On device this hops to the UI runtime and blocks until the worklet returns.
+// There is one runtime in tests, so running it inline preserves the property
+// callers rely on: everything inside has been applied by the time it returns.
+// A jest.fn so tests can assert how many transactions a reset takes.
+export const runOnUISync = jest.fn(
+  <Args extends unknown[], ReturnValue>(
+    worklet: (...args: Args) => ReturnValue,
+    ...args: Args
+  ): ReturnValue => worklet(...args)
+);
+
 export default {
   scheduleOnRN,
   scheduleOnUI,
   scheduleOnRuntime,
+  runOnUISync,
 };

--- a/src/__tests__/fen-reactivity.test.tsx
+++ b/src/__tests__/fen-reactivity.test.tsx
@@ -1,5 +1,6 @@
 import React from 'react';
 import { act, create } from 'react-test-renderer';
+import { runOnUISync } from 'react-native-worklets';
 import { useBoardState } from '../state/use-board-state';
 import type { BoardState } from '../state/types';
 import { SQUARES } from '../state/types';
@@ -140,5 +141,66 @@ describe('useBoardState — fen prop reactivity', () => {
     const initialChess = handle.current.chess;
     handle.update(KIWIPETE_FEN);
     expect(handle.current.chess).toBe(initialChess);
+  });
+
+  describe('reset atomicity', () => {
+    const runOnUISyncSpy = runOnUISync as unknown as jest.Mock;
+
+    beforeEach(() => {
+      runOnUISyncSpy.mockClear?.();
+    });
+
+    it('applies the whole reset in a single UI-runtime transaction', () => {
+      const handle = renderWithFen(STARTING_FEN);
+      const callsAfterMount = runOnUISyncSpy.mock.calls.length;
+
+      handle.update(KIWIPETE_FEN);
+
+      // One transaction for the swap — not one write per square. Skia cannot
+      // draw a half-applied position if the whole reset lands together.
+      expect(runOnUISyncSpy.mock.calls.length - callsAfterMount).toBe(1);
+    });
+
+    it('carries every square and every board-level field in that one call', () => {
+      const handle = renderWithFen(STARTING_FEN);
+      runOnUISyncSpy.mockClear();
+
+      handle.update(KIWIPETE_FEN);
+
+      const { boardState } = handle.current;
+      // All 64 squares reflect the new position...
+      const pieces = collectPieces(boardState);
+      expect(pieces.e4).toBe('wp');
+      expect(pieces.f6).toBe('bn');
+      // Kiwipete has a white bishop on e2, not the starting pawn.
+      expect(pieces.e2).toBe('wb');
+      expect(Object.keys(pieces)).toHaveLength(64);
+      // ...and so does the board-level state, from the same transaction.
+      expect(boardState.turn.get()).toBe('w');
+      expect(boardState.selectedSquare.get()).toBeNull();
+      expect(boardState.validMoves.get()).toEqual([]);
+      expect(boardState.lastMove.get()).toBeNull();
+      expect(boardState.kingInCheckSquare.get()).toBeNull();
+    });
+
+    it('does not run a transaction when the fen prop is unchanged', () => {
+      const handle = renderWithFen(STARTING_FEN);
+      runOnUISyncSpy.mockClear();
+
+      handle.update(STARTING_FEN);
+
+      expect(runOnUISyncSpy).not.toHaveBeenCalled();
+    });
+
+    it('does not run a transaction for an invalid fen', () => {
+      const handle = renderWithFen(STARTING_FEN);
+      runOnUISyncSpy.mockClear();
+
+      handle.update('not-a-fen');
+
+      // Bails before the transaction, leaving the position on screen intact.
+      expect(runOnUISyncSpy).not.toHaveBeenCalled();
+      expect(handle.current.boardState.squares.e2.piece.get()).toBe('wp');
+    });
   });
 });

--- a/src/state/use-board-state.ts
+++ b/src/state/use-board-state.ts
@@ -1,5 +1,6 @@
-import { useRef, useMemo, useEffect } from 'react';
+import { useRef, useMemo, useEffect, useLayoutEffect } from 'react';
 import { useSharedValue, makeMutable } from 'react-native-reanimated';
+import { runOnUISync } from 'react-native-worklets';
 import { Chess } from 'chess.js';
 import type { Square, Color } from 'chess.js';
 import type {
@@ -172,7 +173,10 @@ export const useBoardState = (
   // clear board-level state (selection, valid moves, last move, check state,
   // highlights). Programmatic moves still go through ref.current.move.
   const isFirstFenRef = useRef(true);
-  useEffect(() => {
+  // `useLayoutEffect`, not `useEffect`: the reset must land before the browser
+  // /host paints the commit that carried the new `fen`, otherwise one frame
+  // shows the new position's props against the old board.
+  useLayoutEffect(() => {
     if (isFirstFenRef.current) {
       isFirstFenRef.current = false;
       return;
@@ -189,25 +193,45 @@ export const useBoardState = (
       }
     }
     const { pieceSize: ps, flipped: fl } = layoutRef.current;
-    for (const square of SQUARES) {
-      const state = squareStates[square];
-      const piece = getPieceCodeFromBoard(chess, square);
-      const pos = squareToPosition(square, ps, fl);
-      state.piece.set(piece);
-      state.translateX.set(pos.x);
-      state.translateY.set(pos.y);
-      state.scale.set(1);
-      state.zIndex.set(0);
-      state.lastMove.set(false);
-      state.inCheck.set(false);
-      highlightStates[square].color.set(null);
-    }
-    turn.set(chess.turn());
-    selectedSquare.set(null);
-    validMoves.set([]);
-    lastMove.set(null);
-    isCheck.set(chess.isCheck());
-    kingInCheckSquare.set(null);
+    const pieces = SQUARES.map((square) =>
+      getPieceCodeFromBoard(chess, square)
+    );
+    const positions = SQUARES.map((square) => squareToPosition(square, ps, fl));
+    const nextTurn = chess.turn();
+    const nextIsCheck = chess.isCheck();
+
+    // Commit every square in a single UI-runtime transaction. Setting each
+    // field from JS schedules hundreds of independent updates, and Skia is
+    // free to draw between any two of them — during rapid FEN swaps that
+    // surfaces as frames holding half the old position and half the new one.
+    runOnUISync(
+      (nextPieces, nextPositions, nextTurnValue, nextCheckValue) => {
+        'worklet';
+        for (let index = 0; index < SQUARES.length; index += 1) {
+          const square = SQUARES[index];
+          const state = squareStates[square];
+          const position = nextPositions[index];
+          state.piece.set(nextPieces[index]);
+          state.translateX.set(position.x);
+          state.translateY.set(position.y);
+          state.scale.set(1);
+          state.zIndex.set(0);
+          state.lastMove.set(false);
+          state.inCheck.set(false);
+          highlightStates[square].color.set(null);
+        }
+        turn.set(nextTurnValue);
+        selectedSquare.set(null);
+        validMoves.set([]);
+        lastMove.set(null);
+        isCheck.set(nextCheckValue);
+        kingInCheckSquare.set(null);
+      },
+      pieces,
+      positions,
+      nextTurn,
+      nextIsCheck
+    );
   }, [
     // `initialFen` is the ONLY legitimate reset trigger. `pieceSize`/`flipped`
     // are read from layoutRef so flips/resizes don't reload the position.


### PR DESCRIPTION
## Problem

Changing the `fen` prop rebuilt the board with ~450 individual shared-value writes issued one at a time from JS — 7 fields × 64 squares, plus board-level state:

```ts
for (const square of SQUARES) {
  state.piece.set(piece);
  state.translateX.set(pos.x);
  state.translateY.set(pos.y);
  state.scale.set(1);
  state.zIndex.set(0);
  // ...
}
```

Each `.set()` schedules its own update and Skia may draw between any two of them. During rapid fen swaps — stepping through a game, cycling puzzles — that surfaces as frames holding half the old position and half the new one.

## Fix

Precompute pieces and positions on the JS side, then commit the entire reset inside one `runOnUISync` worklet. The UI runtime sees a single transaction, so there is no intermediate state to draw.

Also `useEffect` → `useLayoutEffect`. The reset must land before the host paints the commit that carried the new `fen`; otherwise the first frame after the swap still shows the old board.

`runOnUISync` is part of `react-native-worklets` ≥ 0.7 (`threads.d.ts`), which matches the package's existing peer range.

## Test infrastructure

Two mock problems surfaced while writing this, both worth fixing on their own merits:

**`react-native-worklets` was never mapped.** The mock existed but jest resolved the real package, whose node build has no `runOnUISync`. Now mapped; the mock gained `runOnUISync`, which runs the worklet inline — preserving the property callers depend on, that everything inside has been applied by the time it returns.

**The reanimated mock's `useSharedValue` returned a new object on every render.** The real hook returns the same mutable for the component's lifetime. Under the old mock, every shared value looked like an unstable dependency, so effects keyed on them re-ran on *every render* in tests while behaving correctly on device. That masks exactly the class of bug dependency arrays exist to catch — and it made "does this reset run when it shouldn't?" impossible to assert. Now memoized via `useRef`.

## Tests

New `reset atomicity` block:

- a fen swap costs **exactly one** transaction (fails on `main`: zero, because the writes are scattered)
- that one transaction carries all 64 squares *and* board-level state
- an unchanged fen runs **no** transaction
- an invalid fen runs none and leaves the visible position intact

Full suite: 260 passed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)