### PR TITLE
feat: make resetBoard awaitable

### DIFF
--- a/README.md
+++ b/README.md
@@ -288,9 +288,13 @@ Highlights a square. Default color is `'rgba(255,255,0, 0.5)'`.
 
 Clears all highlighted squares.
 
-### `resetBoard(fen?: string, opts?): void`
+### `resetBoard(fen?: string, opts?): Promise<void>`
 
 Resets the board. Optionally loads a new FEN position.
+
+Resolves once a `slide` animation has settled — or was cancelled by a newer
+interaction. Without `slide` there is nothing to animate and the returned
+promise is already resolved, so awaiting is always optional.
 
 `opts` enables animated history navigation when stepping between positions:
 
@@ -299,10 +303,11 @@ Resets the board. Optionally loads a new FEN position.
 
 ```tsx
 // step forward through a stored game
-ref.current?.resetBoard(nextFen, {
+await ref.current?.resetBoard(nextFen, {
   slide: { from: move.from, to: move.to },
   lastMove: { from: move.from, to: move.to },
 });
+// the slide has landed — safe to start the next one without it being cancelled
 ```
 
 ### `getState(): ChessboardState`

--- a/src/__tests__/move-executor.test.ts
+++ b/src/__tests__/move-executor.test.ts
@@ -543,6 +543,95 @@ describe('createMoveExecutor', () => {
     });
   });
 
+  describe('resetBoard completion', () => {
+    const AFTER_E4 =
+      'rnbqkbnr/pppppppp/8/8/4P3/8/PPPP1PPP/RNBQKBNR b KQkq - 0 1';
+
+    const holdSprings = () => {
+      const settles: Array<(finished?: boolean) => void> = [];
+      const spy = jest.spyOn(Reanimated, 'withSpring').mockImplementation(((
+        toValue: unknown,
+        _config?: unknown,
+        callback?: (finished?: boolean) => void
+      ) => {
+        if (callback) settles.push(callback);
+        return toValue;
+      }) as typeof Reanimated.withSpring);
+      return { settles, spy };
+    };
+
+    it('resolves immediately when there is nothing to animate', async () => {
+      const chess = new Chess();
+      const boardState = createMockBoardState(chess, PIECE_SIZE);
+      const executor = createMoveExecutor(chess, boardState, config, {});
+
+      await expect(executor.resetBoard()).resolves.toBeUndefined();
+    });
+
+    it('resolves for an invalid fen instead of hanging', async () => {
+      const chess = new Chess();
+      const boardState = createMockBoardState(chess, PIECE_SIZE);
+      const executor = createMoveExecutor(chess, boardState, config, {});
+
+      await expect(executor.resetBoard('not-a-fen')).resolves.toBeUndefined();
+      // The position on screen is untouched.
+      expect(boardState.squares.e2.piece.get()).toBe('wp');
+    });
+
+    it('waits for the slide to settle before resolving', async () => {
+      const chess = new Chess();
+      const boardState = createMockBoardState(chess, PIECE_SIZE);
+      const executor = createMoveExecutor(chess, boardState, config, {});
+      const { settles, spy } = holdSprings();
+
+      try {
+        let settled = false;
+        const done = executor
+          .resetBoard(AFTER_E4, { slide: { from: 'e2', to: 'e4' } })
+          .then(() => {
+            settled = true;
+          });
+
+        // Spring still in flight: the promise must not have resolved, and the
+        // sliding piece keeps its raised zIndex.
+        await Promise.resolve();
+        expect(settled).toBe(false);
+        expect(boardState.squares.e4.zIndex.get()).toBe(100);
+
+        settles.forEach((settle) => settle(true));
+        await done;
+
+        expect(settled).toBe(true);
+        expect(boardState.squares.e4.zIndex.get()).toBe(0);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+
+    it('resolves — and leaves zIndex alone — when the slide is cancelled', async () => {
+      const chess = new Chess();
+      const boardState = createMockBoardState(chess, PIECE_SIZE);
+      const executor = createMoveExecutor(chess, boardState, config, {});
+      const { settles, spy } = holdSprings();
+
+      try {
+        const done = executor.resetBoard(AFTER_E4, {
+          slide: { from: 'e2', to: 'e4' },
+        });
+
+        // A newer pan cancelled the spring. It owns the square now, so this
+        // stale rollback must not reset zIndex — but the caller still has to
+        // be released rather than left awaiting forever.
+        settles.forEach((settle) => settle(false));
+        await expect(done).resolves.toBeUndefined();
+
+        expect(boardState.squares.e4.zIndex.get()).toBe(100);
+      } finally {
+        spy.mockRestore();
+      }
+    });
+  });
+
   describe('undo', () => {
     it('reverts the last move', () => {
       const chess = new Chess();

--- a/src/hooks/use-chessboard-ref.ts
+++ b/src/hooks/use-chessboard-ref.ts
@@ -19,13 +19,20 @@ export interface ChessboardRef {
   undo: () => Move | null;
   highlight: (params: { square: Square; color?: string }) => void;
   resetAllHighlightedSquares: () => void;
+  /**
+   * Resets the board to `fen` (or the starting position).
+   *
+   * Resolves once a `slide` animation has settled, so callers can sequence
+   * work against it. With no `slide` there is nothing to animate and the
+   * promise is already resolved — awaiting is optional in every case.
+   */
   resetBoard: (
     fen?: string,
     opts?: {
       slide?: { from: Square; to: Square };
       lastMove?: { from: Square; to: Square } | null;
     }
-  ) => void;
+  ) => Promise<void>;
   getState: () => ChessboardState;
 }
 
@@ -92,7 +99,7 @@ export const useChessboardRef = ({
         lastMove?: { from: Square; to: Square } | null;
       }
     ) => {
-      moveExecutor.resetBoard(fen, opts);
+      return moveExecutor.resetBoard(fen, opts);
     },
     [moveExecutor]
   );

--- a/src/state/move-executor.ts
+++ b/src/state/move-executor.ts
@@ -319,14 +319,14 @@ export const createMoveExecutor = (
       // this position). Pass null to clear.
       lastMove?: { from: Square; to: Square } | null;
     }
-  ) => {
+  ): Promise<void> => {
     if (fen) {
       try {
         chess.load(fen);
       } catch {
         // Invalid FEN — leave the chess instance untouched and bail out so
         // the board state stays consistent with what's actually on screen.
-        return;
+        return Promise.resolve();
       }
     } else {
       chess.reset();
@@ -335,6 +335,16 @@ export const createMoveExecutor = (
     const slide = opts?.slide;
     const lastMove = opts?.lastMove ?? null;
     const board = chess.board();
+
+    // Resolves once the slide has settled (or was cancelled), so callers can
+    // sequence work against the animation instead of guessing with a timeout.
+    // With no slide there is nothing to wait for.
+    let resolveSlide: (() => void) | undefined;
+    const slideComplete = slide
+      ? new Promise<void>((resolve) => {
+          resolveSlide = resolve;
+        })
+      : Promise.resolve();
 
     // Update every square. When `slide` is given, the piece landing on
     // `slide.to` starts at `slide.from` and springs home — so stepping through
@@ -365,9 +375,12 @@ export const createMoveExecutor = (
           // zIndex drop rides the axis that actually travels (a no-travel
           // spring settles instantly — see commitMove in executeMove).
           const slidesVertically = pos.y !== fromPos.y;
-          const dropZIndex = () => {
+          const dropZIndex = (finished?: boolean) => {
             'worklet';
-            sq.zIndex.set(0);
+            // A newer pan may cancel this spring. It then owns the square's
+            // zIndex, and this stale rollback must leave it alone.
+            if (finished) sq.zIndex.set(0);
+            if (resolveSlide) scheduleOnRN(resolveSlide);
           };
           sq.translateX.set(
             withSpring(
@@ -423,6 +436,8 @@ export const createMoveExecutor = (
       callbacks.effectSharedValues.progress.set(0);
       callbacks.effectSharedValues.trigger.set('');
     }
+
+    return slideComplete;
   };
 
   const undo = (): Move | null => {


### PR DESCRIPTION
## Problem

`resetBoard(fen, { slide })` starts a spring and returns immediately, so a caller stepping through a stored game has no way to know when the piece landed. The choices were guessing with a `setTimeout`, or firing the next reset early and cancelling the animation mid-flight.

## Fix

Return a promise that resolves when the slide settles.

- **No `slide`** → nothing to animate, promise is already resolved. Awaiting stays optional everywhere.
- **Cancelled spring** → also resolves. A newer pan or reset taking over must release the previous caller, not leave it awaiting forever.

```tsx
await ref.current?.resetBoard(nextFen, {
  slide: { from: move.from, to: move.to },
  lastMove: { from: move.from, to: move.to },
});
// the slide has landed — safe to start the next one
```

### Drive-by fix

Wiring the completion callback exposed that `dropZIndex` lacked the `finished` guard its sibling spring callbacks already have:

```ts
const dropZIndex = () => {
  'worklet';
  sq.zIndex.set(0);   // ran even when the spring was cancelled
};
```

A cancelled slide therefore stripped the raised `zIndex` from a square a newer gesture had just taken ownership of — the same class of bug as #51, from the other side. Now guarded.

## API change — needs a semver call

`resetBoard(): void` → `resetBoard(): Promise<void>`.

- Existing statement-position calls (`ref.current?.resetBoard()`) compile and behave identically. This only widens what callers may do with the return value.
- Consumers linting with `no-floating-promises` will get new warnings on un-awaited call sites and will want `void ref.current?.resetBoard()`.

Strictly it changes a declared public return type, so it is your call whether this rides a **minor** or waits for a **major**. I have not tagged it either way.

## Tests

New `resetBoard completion` block:

- resolves immediately with no `slide`
- resolves for an invalid fen instead of hanging, leaving the position intact
- does **not** resolve while the spring is in flight; resolves once it settles, and `zIndex` returns to 0
- resolves when the spring is cancelled, and leaves `zIndex` raised for whoever now owns the square

Full suite: 264 passed.

Note on verification: without the source change this test file does not compile (it awaits a `void`), so "fails on main" here means a type error rather than a red assertion.

🤖 Generated with [Claude Code](https://claude.com/claude-code)