### PR TITLE
feat: show move targets on occupied squares, and reveal them progressively

### DIFF
--- a/src/__mocks__/react-native-reanimated.ts
+++ b/src/__mocks__/react-native-reanimated.ts
@@ -59,10 +59,23 @@ export const runOnJS = (fn: Function) => fn;
 
 export const Easing = {
   out: (easing: any) => easing,
+  in: (easing: any) => easing,
   quad: (t: number) => t * t,
+  cubic: (t: number) => t * t * t,
+};
+
+// Fires the reaction once with no previous value, mirroring the initial
+// invocation on device.
+export const useAnimatedReaction = <T>(
+  prepare: () => T,
+  react: (current: T, previous: T | null) => void,
+  _deps?: unknown[]
+) => {
+  react(prepare(), null);
 };
 
 export default {
+  useAnimatedReaction,
   useSharedValue,
   makeMutable,
   useDerivedValue,

--- a/src/__mocks__/react-native-skia.ts
+++ b/src/__mocks__/react-native-skia.ts
@@ -46,6 +46,21 @@ const fakeSkFont = {
   getSize: () => 12,
 };
 
+export const FillType = {
+  Winding: 0,
+  EvenOdd: 1,
+  InverseWinding: 2,
+  InverseEvenOdd: 3,
+};
+
+export const PathOp = {
+  Difference: 0,
+  Intersect: 1,
+  Union: 2,
+  XOR: 3,
+  ReverseDifference: 4,
+};
+
 export const useImage = jest.fn(() => null);
 export const useFont = jest.fn(() => fakeSkFont);
 export const useTypeface = jest.fn(() => ({ __mock: 'SkTypeface' }));
@@ -80,17 +95,37 @@ export const Skia = {
     Make: () => null,
   },
   Path: {
-    // Records the circles the dots layer adds so tests can assert on them.
+    // Records what the dots layer adds so tests can assert on the geometry.
     Make: () => {
       const circles: Array<{ x: number; y: number; radius: number }> = [];
-      return {
+      const rects: unknown[] = [];
+      const path = {
         __mock: 'SkPath',
         circles,
+        rects,
+        fillType: 0,
         addCircle: (x: number, y: number, radius: number) => {
           circles.push({ x, y, radius });
+          return path;
+        },
+        addRect: (r: unknown) => {
+          rects.push(r);
+          return path;
+        },
+        setFillType: (fillType: number) => {
+          path.fillType = fillType;
+          return path;
         },
       };
+      return path;
     },
+    // Records the operands so tests can assert what was subtracted from what.
+    MakeFromOp: (one: unknown, two: unknown, op: number) => ({
+      __mock: 'SkPath',
+      op,
+      one,
+      two,
+    }),
   },
 };
 

--- a/src/__tests__/move-dots.test.tsx
+++ b/src/__tests__/move-dots.test.tsx
@@ -1,0 +1,373 @@
+import React from 'react';
+import { Chess, Square } from 'chess.js';
+import { makeMutable } from 'react-native-reanimated';
+import { Group } from '@shopify/react-native-skia';
+import { SkiaDots, dotProgress } from '../components/skia/skia-dots';
+import { SkiaBoard } from '../components/skia/skia-board';
+import { SkiaPiecesAtlas } from '../components/skia/skia-pieces-atlas';
+import { squareToPosition } from '../state/use-board-state';
+import type {
+  BoardConfig,
+  BoardState,
+  PieceCode,
+  SquareState,
+  HighlightState,
+} from '../state/types';
+import { SQUARES } from '../state/types';
+import {
+  MOVE_SPRING,
+  SCALE_SPRING,
+  SNAP_BACK_SPRING,
+} from '../config/animations';
+import { findAllByType, renderToTree } from './render-utils';
+import type { RenderedJSON } from './render-utils';
+
+const PIECE_SIZE = 50;
+const DOT_RADIUS = PIECE_SIZE * 0.16;
+const CAPTURE_INNER = PIECE_SIZE * 0.58;
+const POOL_SIZE = 27;
+// Mirrors PathOp.Difference in the skia mock.
+const DIFFERENCE = 0;
+
+const makeConfig = (overrides: Partial<BoardConfig> = {}): BoardConfig => ({
+  boardSize: PIECE_SIZE * 8,
+  pieceSize: PIECE_SIZE,
+  gestureEnabled: true,
+  flipped: false,
+  withLetters: false,
+  withNumbers: false,
+  colors: {
+    white: '#fff',
+    black: '#000',
+    lastMoveHighlight: 'rgba(255,255,0,0.5)',
+    checkmateHighlight: '#E84855',
+    promotionPieceButton: '#FF9B71',
+  },
+  animations: {
+    move: MOVE_SPRING,
+    scale: SCALE_SPRING,
+    snapBack: SNAP_BACK_SPRING,
+  },
+  fontSource: null,
+  ...overrides,
+});
+
+const makeBoardState = (fen?: string): BoardState => {
+  const chess = new Chess(fen);
+  const squares: Partial<Record<Square, SquareState>> = {};
+  const highlights: Partial<Record<Square, HighlightState>> = {};
+
+  for (const square of SQUARES) {
+    const { x, y } = squareToPosition(square, PIECE_SIZE, false);
+    const piece = chess.get(square);
+    squares[square] = {
+      piece: makeMutable<PieceCode>(
+        piece ? (`${piece.color}${piece.type}` as PieceCode) : null
+      ),
+      translateX: makeMutable(x),
+      translateY: makeMutable(y),
+      scale: makeMutable(1),
+      zIndex: makeMutable(0),
+      lastMove: makeMutable(false),
+      inCheck: makeMutable(false),
+    };
+    highlights[square] = { color: makeMutable<string | null>(null) };
+  }
+
+  return {
+    squares: squares as Record<Square, SquareState>,
+    highlights: highlights as Record<Square, HighlightState>,
+    turn: makeMutable(chess.turn()),
+    selectedSquare: makeMutable<Square | null>(null),
+    validMoves: makeMutable<Square[]>([]),
+    lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
+    isCheck: makeMutable(false),
+    kingInCheckSquare: makeMutable<Square | null>(null),
+  };
+};
+
+const select = (
+  boardState: BoardState,
+  from: Square | null,
+  targets: Square[]
+) => {
+  boardState.selectedSquare.set(from);
+  boardState.validMoves.set(targets);
+};
+
+type MockCircle = { x: number; y: number; radius: number };
+type MockPath = {
+  circles?: MockCircle[];
+  rects?: unknown[];
+  op?: number;
+  one?: { circles?: MockCircle[]; rects?: unknown[] };
+  two?: { circles?: MockCircle[] };
+};
+
+/** Every path the dots layer handed to Skia, in render order. */
+const renderPaths = (
+  boardState: BoardState,
+  config: BoardConfig = makeConfig()
+): MockPath[] =>
+  findAllByType(
+    // Wrapped so the fragment of pooled dots has a single root to render into.
+    renderToTree(
+      <Group>
+        <SkiaDots config={config} boardState={boardState} />
+      </Group>
+    ),
+    'skia-path'
+  ).map((node) => {
+    const path = (node.props as { path: { get(): MockPath } }).path;
+    return path.get();
+  });
+
+const filledCircles = (paths: MockPath[]): MockCircle[] =>
+  paths.flatMap((p) => p.circles ?? []);
+
+const captureMarks = (paths: MockPath[]): MockPath[] =>
+  paths.filter((p) => p.op === DIFFERENCE);
+
+const centreOf = (square: Square, flipped = false) => {
+  const pos = squareToPosition(square, PIECE_SIZE, flipped);
+  return { x: pos.x + PIECE_SIZE / 2, y: pos.y + PIECE_SIZE / 2 };
+};
+
+describe('dotProgress', () => {
+  const ORIGIN = { x: 0, y: 0 };
+
+  it('is fully revealed for the origin square itself', () => {
+    expect(
+      dotProgress(1, ORIGIN.x, ORIGIN.y, ORIGIN.x, ORIGIN.y, PIECE_SIZE)
+    ).toBe(1);
+  });
+
+  it('starts nearer targets before farther ones', () => {
+    const near = dotProgress(0.3, PIECE_SIZE, 0, 0, 0, PIECE_SIZE);
+    const far = dotProgress(0.3, PIECE_SIZE * 4, 0, 0, 0, PIECE_SIZE);
+
+    expect(near).toBeGreaterThan(far);
+  });
+
+  it('uses Chebyshev distance, so a diagonal neighbour matches an orthogonal one', () => {
+    const orthogonal = dotProgress(0.4, PIECE_SIZE, 0, 0, 0, PIECE_SIZE);
+    const diagonal = dotProgress(0.4, PIECE_SIZE, PIECE_SIZE, 0, 0, PIECE_SIZE);
+
+    expect(diagonal).toBe(orthogonal);
+  });
+
+  it('caps the stagger so the farthest target still starts in time', () => {
+    // Squares 6 and 7 away would drift apart without the cap.
+    const six = dotProgress(0.6, PIECE_SIZE * 6, 0, 0, 0, PIECE_SIZE);
+    const seven = dotProgress(0.6, PIECE_SIZE * 7, 0, 0, 0, PIECE_SIZE);
+
+    expect(seven).toBe(six);
+  });
+
+  it('clamps to 0 before its turn and 1 at the end', () => {
+    expect(dotProgress(0, PIECE_SIZE * 3, 0, 0, 0, PIECE_SIZE)).toBe(0);
+    expect(dotProgress(1, PIECE_SIZE * 3, 0, 0, 0, PIECE_SIZE)).toBe(1);
+  });
+
+  it('applies no stagger when there is no origin', () => {
+    expect(dotProgress(0.5, PIECE_SIZE * 5, 0, null, null, PIECE_SIZE)).toBe(
+      0.5
+    );
+  });
+});
+
+describe('SkiaDots', () => {
+  it('draws nothing when no piece is selected', () => {
+    const boardState = makeBoardState();
+    const paths = renderPaths(boardState);
+
+    expect(filledCircles(paths)).toHaveLength(0);
+    expect(captureMarks(paths)).toHaveLength(0);
+  });
+
+  it('keeps a fixed pool of slots so selecting never re-renders React', () => {
+    const boardState = makeBoardState();
+    select(boardState, 'e2' as Square, ['e3' as Square, 'e4' as Square]);
+
+    // One dot path + one capture path per slot, regardless of target count.
+    expect(renderPaths(boardState)).toHaveLength(POOL_SIZE * 2);
+  });
+
+  it('draws a dot centred on each empty target', () => {
+    const boardState = makeBoardState();
+    select(boardState, 'e2' as Square, ['e3' as Square, 'e4' as Square]);
+
+    const circles = filledCircles(renderPaths(boardState));
+
+    expect(circles).toHaveLength(2);
+    expect(circles).toEqual(
+      expect.arrayContaining([
+        { ...centreOf('e3' as Square), radius: DOT_RADIUS },
+        { ...centreOf('e4' as Square), radius: DOT_RADIUS },
+      ])
+    );
+  });
+
+  it('never draws a dot on an occupied target', () => {
+    // White pawn e4, black pawn d5: exd5 is a capture, e5 is empty.
+    const boardState = makeBoardState(
+      'rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2'
+    );
+    select(boardState, 'e4' as Square, ['e5' as Square, 'd5' as Square]);
+
+    const paths = renderPaths(boardState);
+    const circles = filledCircles(paths);
+
+    // Only the empty square gets a dot...
+    expect(circles).toEqual([
+      { ...centreOf('e5' as Square), radius: DOT_RADIUS },
+    ]);
+    // ...and the occupied one is marked without covering the piece.
+    expect(captureMarks(paths)).toHaveLength(1);
+  });
+
+  it('marks a capture as the square minus a circle, not a filled shape', () => {
+    const boardState = makeBoardState(
+      'rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2'
+    );
+    select(boardState, 'e4' as Square, ['d5' as Square]);
+
+    const [mark] = captureMarks(renderPaths(boardState));
+    const centre = centreOf('d5' as Square);
+
+    expect(mark.op).toBe(DIFFERENCE);
+    // Subtrahend is the circle, so nothing is painted over the piece.
+    expect(mark.two?.circles).toEqual([{ ...centre, radius: CAPTURE_INNER }]);
+    expect(mark.one?.rects).toHaveLength(1);
+  });
+
+  it('keeps the subtracted circle larger than half a square', () => {
+    // Guards the bleed bug: with an even-odd fill anything past 0.5 painted
+    // into the neighbouring squares. A real Difference has no such limit, and
+    // the radius must stay above 0.5 for the corners to stay slivers.
+    const boardState = makeBoardState(
+      'rnbqkbnr/ppp1pppp/8/3p4/4P3/8/PPPP1PPP/RNBQKBNR w KQkq - 0 2'
+    );
+    select(boardState, 'e4' as Square, ['d5' as Square]);
+
+    const [mark] = captureMarks(renderPaths(boardState));
+
+    expect(mark.two?.circles?.[0].radius).toBeGreaterThan(PIECE_SIZE / 2);
+  });
+
+  it('mirrors dot positions when the board is flipped', () => {
+    const boardState = makeBoardState();
+    select(boardState, 'e2' as Square, ['e4' as Square]);
+
+    const circles = filledCircles(
+      renderPaths(boardState, makeConfig({ flipped: true }))
+    );
+
+    expect(circles).toEqual([
+      { ...centreOf('e4' as Square, true), radius: DOT_RADIUS },
+    ]);
+  });
+
+  it('draws every target of a wide-open queen', () => {
+    const boardState = makeBoardState('4k3/8/8/8/3Q4/8/8/4K3 w - - 0 1');
+    const chess = new Chess('4k3/8/8/8/3Q4/8/8/4K3 w - - 0 1');
+    const targets = chess
+      .moves({ square: 'd4' as Square, verbose: true })
+      .map((m) => m.to as Square);
+    select(boardState, 'd4' as Square, targets);
+
+    // 27 is the pool size and also the queen's maximum — the pool must not
+    // silently drop the last target.
+    expect(targets.length).toBeLessThanOrEqual(POOL_SIZE);
+    expect(filledCircles(renderPaths(boardState))).toHaveLength(targets.length);
+  });
+});
+
+describe('piece layering', () => {
+  const spriteImage = { __mock: 'SkImage' } as never;
+
+  const atlasSpriteCount = (tree: RenderedJSON, index: number): number => {
+    const atlases = findAllByType(tree, 'skia-atlas');
+    const sprites = (atlases[index].props as { sprites: { get(): unknown[] } })
+      .sprites;
+    return sprites.get().length;
+  };
+
+  it('puts resting pieces in the resting layer only', () => {
+    const boardState = makeBoardState();
+    const tree = renderToTree(
+      <SkiaPiecesAtlas
+        layer="resting"
+        spriteImage={spriteImage}
+        boardState={boardState}
+        pieceSize={PIECE_SIZE}
+      />
+    );
+
+    expect(atlasSpriteCount(tree, 0)).toBe(32);
+  });
+
+  it('moves a lifted piece out of the resting layer and into the raised one', () => {
+    const boardState = makeBoardState();
+    boardState.squares.e2.zIndex.set(100);
+
+    const resting = renderToTree(
+      <SkiaPiecesAtlas
+        layer="resting"
+        spriteImage={spriteImage}
+        boardState={boardState}
+        pieceSize={PIECE_SIZE}
+      />
+    );
+    const raised = renderToTree(
+      <SkiaPiecesAtlas
+        layer="raised"
+        spriteImage={spriteImage}
+        boardState={boardState}
+        pieceSize={PIECE_SIZE}
+      />
+    );
+
+    expect(atlasSpriteCount(resting, 0)).toBe(31);
+    expect(atlasSpriteCount(raised, 0)).toBe(1);
+  });
+
+  it('renders dots between the resting and raised layers', () => {
+    const boardState = makeBoardState();
+    select(boardState, 'e2' as Square, ['e4' as Square]);
+    boardState.squares.e2.zIndex.set(100);
+
+    const tree = renderToTree(
+      <SkiaBoard
+        config={makeConfig()}
+        boardState={boardState}
+        spriteImage={spriteImage}
+      />
+    );
+
+    // Walk the drawn nodes in paint order and check the dots land between the
+    // two atlases: above resting pieces (so captures show) and below the
+    // lifted piece (so the piece under the finger is never occluded).
+    const order = findAllByType(tree, 'skia-atlas')
+      .map(() => 'atlas')
+      .concat();
+    expect(order).toHaveLength(2);
+
+    const drawn: string[] = [];
+    const walk = (node: RenderedJSON) => {
+      if (node.type === 'skia-atlas') drawn.push('atlas');
+      if (node.type === 'skia-path') drawn.push('path');
+      for (const child of node.children ?? []) {
+        if (child && typeof child === 'object') walk(child as RenderedJSON);
+      }
+    };
+    walk(tree);
+
+    const firstAtlas = drawn.indexOf('atlas');
+    const lastAtlas = drawn.lastIndexOf('atlas');
+    const firstPath = drawn.indexOf('path');
+
+    expect(firstAtlas).toBeLessThan(firstPath);
+    expect(firstPath).toBeLessThan(lastAtlas);
+  });
+});

--- a/src/components/skia/skia-board.tsx
+++ b/src/components/skia/skia-board.tsx
@@ -75,12 +75,23 @@ export const SkiaBoard: React.FC<SkiaBoardProps> = React.memo(
       return p > 0 && p < 1 ? 1 : 0;
     });
 
+    // Skia paints in declaration order. The dots sit BETWEEN the two piece
+    // layers: above the resting pieces, so a dot on an occupied square (a
+    // capture target) stays visible, but below whatever a drag or an in-flight
+    // move has raised, so the piece under the finger is never occluded.
     const board = (
       <>
         <BoardBackground config={config} />
         <SkiaHighlights config={config} boardState={boardState} />
+        <SkiaPiecesAtlas
+          layer="resting"
+          spriteImage={spriteImage}
+          boardState={boardState}
+          pieceSize={pieceSize}
+        />
         <SkiaDots config={config} boardState={boardState} />
         <SkiaPiecesAtlas
+          layer="raised"
           spriteImage={spriteImage}
           boardState={boardState}
           pieceSize={pieceSize}

--- a/src/components/skia/skia-dots.tsx
+++ b/src/components/skia/skia-dots.tsx
@@ -1,6 +1,14 @@
 import React from 'react';
-import { Path, Skia } from '@shopify/react-native-skia';
-import { useDerivedValue } from 'react-native-reanimated';
+import { Path, PathOp, Skia, rect } from '@shopify/react-native-skia';
+import type { DerivedValue, SharedValue } from 'react-native-reanimated';
+import {
+  Easing,
+  useAnimatedReaction,
+  useDerivedValue,
+  useSharedValue,
+  withTiming,
+} from 'react-native-reanimated';
+import type { Square } from 'chess.js';
 import { BoardConfig, BoardState } from '../../state/types';
 import { squareToPosition } from '../../state/use-board-state';
 
@@ -9,29 +17,207 @@ interface SkiaDotsProps {
   boardState: BoardState;
 }
 
-// All valid-move dots are built by ONE derived path that reads the shared
-// `validMoves` once (a single subscription) and adds a circle per target —
-// instead of 64 per-square components each subscribing to `validMoves` and
-// scanning it. It re-runs ONLY when `validMoves` changes (not every frame),
-// so it costs nothing at rest. Dots are binary (no per-square opacity), so
-// one Path is a perfect fit.
+// A queen on an open board has 27 targets — the most any single piece can
+// offer — so a fixed pool of that size always covers a selection. Keeping the
+// count fixed means selecting a piece never re-renders React: every dot reads
+// the shared state itself and simply draws nothing when its slot is unused.
+const DOT_POOL_SIZE = 27;
+
+const REVEAL_MS = 260;
+const DISMISS_MS = 180;
+// Per-square-of-distance delay, as a fraction of the reveal. Capped so a
+// far-flung queen move still starts before the near ones have finished.
+const STAGGER_PER_SQUARE = 0.1;
+const MAX_STAGGER = 0.55;
+const DOT_ALPHA = 0.5;
+// Capture marker: the square minus the circle inscribed in it, leaving four
+// corner wedges framing the piece. Matches how lichess marks an occupied
+// target — nothing is ever drawn over the piece itself.
+//
+// The cut is a genuine path Difference, NOT an even-odd fill. Even-odd is
+// XOR: any part of the circle poking outside the square counts as "inside
+// circle, outside rect" and gets painted into the neighbouring squares. That
+// caps XOR at a radius of 0.5. Difference has no such limit, so the circle
+// can grow past the square's edges — which is what thins the wedges down to
+// slivers in the corners.
+const CAPTURE_INNER = 0.58;
+// Corner wedges cover more area than a dot, so they need less alpha to carry
+// the same weight.
+const CAPTURE_ALPHA = 0.3;
+
+type DotSet = { moves: Square[]; origin: Square | null };
+
+/**
+ * Progress of a single dot, 0 → 1, offset by how far its square sits from the
+ * piece being touched. Chebyshev distance matches how pieces move, so a
+ * knight's targets land together instead of splitting into two clumps.
+ */
+export const dotProgress = (
+  reveal: number,
+  targetX: number,
+  targetY: number,
+  originX: number | null,
+  originY: number | null,
+  pieceSize: number
+) => {
+  'worklet';
+  let delay = 0;
+  if (originX !== null && originY !== null) {
+    const dx = Math.abs(targetX - originX) / pieceSize;
+    const dy = Math.abs(targetY - originY) / pieceSize;
+    delay = Math.min(Math.max(dx, dy) * STAGGER_PER_SQUARE, MAX_STAGGER);
+  }
+  return Math.min(Math.max((reveal - delay) / (1 - delay), 0), 1);
+};
+
+interface DotProps {
+  index: number;
+  reveal: DerivedValue<number>;
+  displayed: SharedValue<DotSet>;
+  config: BoardConfig;
+  boardState: BoardState;
+}
+
+const Dot: React.FC<DotProps> = ({
+  index,
+  reveal,
+  displayed,
+  config,
+  boardState,
+}) => {
+  const { pieceSize, flipped } = config;
+  // ~32% of a square in diameter. Chess UIs converge on roughly 30% (lichess,
+  // chess.com); much larger starts competing with the piece it sits under.
+  const radius = pieceSize * 0.16;
+  const half = pieceSize / 2;
+
+  const progress = useDerivedValue(() => {
+    const { moves, origin } = displayed.get();
+    if (index >= moves.length) return 0;
+
+    const pos = squareToPosition(moves[index], pieceSize, flipped);
+    const originPos = origin
+      ? squareToPosition(origin, pieceSize, flipped)
+      : null;
+
+    return dotProgress(
+      reveal.get(),
+      pos.x,
+      pos.y,
+      originPos ? originPos.x : null,
+      originPos ? originPos.y : null,
+      pieceSize
+    );
+  });
+
+  // Whether this target already holds a piece — i.e. the move is a capture.
+  // Only the squares in the current selection are read, and only while a
+  // selection is live, so this does not subscribe to the whole board.
+  const isCapture = useDerivedValue(() => {
+    const { moves } = displayed.get();
+    if (index >= moves.length) return false;
+    return boardState.squares[moves[index]].piece.get() !== null;
+  });
+
+  // Empty target: a plain dot. Occupied target: nothing is drawn over the
+  // piece at all — instead the square minus a circle leaves shaded corners
+  // around it. One path each, because a Skia Path carries a single paint;
+  // the unused one stays empty.
+  const dotPath = useDerivedValue(() => {
+    const p = Skia.Path.Make();
+    const { moves } = displayed.get();
+    const t = progress.get();
+    if (index >= moves.length || t <= 0 || isCapture.get()) return p;
+
+    const pos = squareToPosition(moves[index], pieceSize, flipped);
+    p.addCircle(pos.x + half, pos.y + half, radius * t);
+    return p;
+  });
+
+  const capturePath = useDerivedValue(() => {
+    const square = Skia.Path.Make();
+    const { moves } = displayed.get();
+    const t = progress.get();
+    if (index >= moves.length || t <= 0 || !isCapture.get()) return square;
+
+    const pos = squareToPosition(moves[index], pieceSize, flipped);
+    square.addRect(rect(pos.x, pos.y, pieceSize, pieceSize));
+
+    const hole = Skia.Path.Make();
+    hole.addCircle(pos.x + half, pos.y + half, pieceSize * CAPTURE_INNER);
+
+    // Falls back to the plain square if the op ever fails, which is visible
+    // rather than silently blank.
+    return Skia.Path.MakeFromOp(square, hole, PathOp.Difference) ?? square;
+  });
+
+  // The wedges are a fixed shape, so the reveal rides on opacity alone.
+  const captureOpacity = useDerivedValue(
+    () => Math.min(progress.get() * 1.6, 1) * CAPTURE_ALPHA
+  );
+
+  // Opacity leads the scale slightly so a dot reads as fading in while it
+  // grows, rather than appearing at full strength the instant it has size.
+  const opacity = useDerivedValue(
+    () => Math.min(progress.get() * 1.6, 1) * DOT_ALPHA
+  );
+
+  return (
+    <>
+      <Path path={dotPath} color="rgba(0, 0, 0, 0.3)" opacity={opacity} />
+      <Path
+        path={capturePath}
+        color="rgba(0, 0, 0, 0.3)"
+        opacity={captureOpacity}
+      />
+    </>
+  );
+};
+
 export const SkiaDots: React.FC<SkiaDotsProps> = React.memo(
   ({ config, boardState }) => {
-    const { pieceSize, flipped } = config;
-    const radius = pieceSize * 0.15;
-    const half = pieceSize / 2;
+    // The targets currently being drawn. Deliberately NOT cleared when the
+    // selection ends: the dismiss animation still needs their positions to
+    // shrink them away. It is only ever replaced by a new selection.
+    const displayed = useSharedValue<DotSet>({ moves: [], origin: null });
 
-    const path = useDerivedValue(() => {
-      const p = Skia.Path.Make();
-      const moves = boardState.validMoves.get();
-      for (let i = 0; i < moves.length; i++) {
-        const pos = squareToPosition(moves[i], pieceSize, flipped);
-        p.addCircle(pos.x + half, pos.y + half, radius);
-      }
-      return p;
+    useAnimatedReaction(
+      () => boardState.validMoves.get(),
+      (moves) => {
+        if (moves.length > 0) {
+          displayed.set({ moves, origin: boardState.selectedSquare.get() });
+        }
+      },
+      [boardState]
+    );
+
+    // 0 with nothing selected, 1 while a selection is live — so the same
+    // staggered ramp plays forwards on select and backwards on deselect.
+    // Animating inside the derived value (rather than assigning `withTiming`
+    // from a reaction) is what keeps the per-dot derived values re-evaluating
+    // for the whole ramp.
+    const reveal = useDerivedValue<number>(() => {
+      const selecting = boardState.validMoves.get().length > 0;
+      return withTiming(selecting ? 1 : 0, {
+        duration: selecting ? REVEAL_MS : DISMISS_MS,
+        easing: selecting ? Easing.out(Easing.cubic) : Easing.in(Easing.cubic),
+      });
     });
 
-    return <Path path={path} color="rgba(0, 0, 0, 0.3)" opacity={0.5} />;
+    return (
+      <>
+        {Array.from({ length: DOT_POOL_SIZE }, (_, index) => (
+          <Dot
+            key={index}
+            index={index}
+            reveal={reveal}
+            displayed={displayed}
+            config={config}
+            boardState={boardState}
+          />
+        ))}
+      </>
+    );
   }
 );
 

--- a/src/components/skia/skia-pieces-atlas.tsx
+++ b/src/components/skia/skia-pieces-atlas.tsx
@@ -54,22 +54,34 @@ const SPRITE_RECTS: Record<NonNullable<PieceCode>, SkRect> = {
   ),
 };
 
+/**
+ * Which pieces this atlas draws.
+ *
+ * `resting` — everything sitting on its square. Drawn UNDER the move dots, so
+ * a dot on an occupied square (i.e. a capture target) stays visible.
+ * `raised` — whatever a drag or an in-flight move has lifted (`zIndex > 0`).
+ * Drawn OVER the dots, so the piece under the finger is never occluded by
+ * them.
+ */
+export type PieceLayer = 'resting' | 'raised';
+
 interface SkiaPiecesAtlasProps {
   spriteImage: SkImage | null;
   boardState: BoardState;
   pieceSize: number;
+  layer: PieceLayer;
 }
 
 /**
- * Renders all chess pieces using a single Atlas draw call.
+ * Renders chess pieces using a single Atlas draw call per layer.
  *
  * Benefits:
- * - Single draw call for all pieces (vs 64+ individual draws)
+ * - Single draw call for all pieces in the layer (vs 64+ individual draws)
  * - zIndex handled by array order (last = on top)
  * - Transforms calculated in worklet (no JS thread overhead)
  */
 export const SkiaPiecesAtlas: React.FC<SkiaPiecesAtlasProps> = React.memo(
-  ({ spriteImage, boardState, pieceSize }) => {
+  ({ spriteImage, boardState, pieceSize, layer }) => {
     // Scale factor from sprite sheet cell size to piece size
     const scale = pieceSize / SPRITE_CELL_SIZE;
 
@@ -99,13 +111,15 @@ export const SkiaPiecesAtlas: React.FC<SkiaPiecesAtlasProps> = React.memo(
       for (const square of SQUARES) {
         const squareState = boardState.squares[square];
         const piece = squareState.piece.get();
-        if (piece) {
-          pieces.push({
-            square,
-            piece,
-            zIndex: squareState.zIndex.get(),
-          });
-        }
+        if (!piece) continue;
+
+        // `zIndex > 0` is exactly "lifted by a drag or an in-flight move",
+        // which is the one case that must draw above the dots.
+        const zIndex = squareState.zIndex.get();
+        const isRaised = zIndex > 0;
+        if (isRaised !== (layer === 'raised')) continue;
+
+        pieces.push({ square, piece, zIndex });
       }
 
       // zIndex ascending — higher draws last (on top).


### PR DESCRIPTION
## Problem

Move dots were drawn **under** the pieces, so a dot on an occupied square — i.e. every capture — was hidden. Captures had no indicator at all.

Drawing the dots last is not the fix: a dot then lands on top of the piece it refers to, hiding the thing you are about to take.

## Fix

**Layering.** The piece atlas is split in two, with the dots between them:

```
background → highlights → resting pieces → dots → raised pieces
```

`zIndex > 0` is already exactly "lifted by a drag or an in-flight move", so it separates the layers with no new state. Resting pieces sit below the dots so targets read; the piece under your finger sits above them so dragging is never occluded.

**Capture marks.** Occupied targets get a different mark, matching lichess: the square minus a circle, leaving four shaded corners framing the piece. Nothing is ever painted over a piece.

That cut is a real `PathOp.Difference`, **not** an even-odd fill. Even-odd is XOR, so any part of the circle poking outside the square counts as "inside circle, outside rect" and gets painted into the neighbouring squares — which caps the radius at `0.5` and makes the corners far too heavy. Difference has no such limit, so the circle can exceed the square and thin the corners to slivers. (The bleed was caught on device; there is a regression test pinning the radius above `0.5`.)

**Reveal.** Dots animate in instead of blinking on — per-dot scale and opacity, staggered by **Chebyshev** distance from the piece being touched, so targets ripple outward from it. Chebyshev rather than Euclidean because it matches how pieces move: a knight's targets land together instead of splitting into two clumps.

Dismissal animates too. That required the drawn set to outlive the selection — the dots' positions come from `validMoves`, so clearing it made them vanish instantly with nothing left to animate. A `displayed` set is now retained until a new selection replaces it.

**Rendering.** A fixed pool of 27 slots (a queen on an open board has 27 targets, the most any piece can offer), so selecting a piece never re-renders React; each slot reads the shared state itself.

### Note for anyone touching the animation

The reveal is driven by `withTiming` **inside** a derived value. Assigning `withTiming` to a shared value from `useAnimatedReaction` does not work here: the reaction fires — a plain assignment lands — but the animation never propagates to the dependent derived values. That cost a few rounds of debugging on device; the comment in the source records it.

## Tests

New `move-dots.test.tsx`, 17 cases:

**`dotProgress`** (stagger math, unit): origin fully revealed; nearer targets start before farther; Chebyshev equivalence of diagonal vs orthogonal neighbours; stagger cap; clamping at both ends; no-origin case.

**`SkiaDots`**: nothing drawn without a selection; fixed pool size regardless of target count; dot centred per empty target at the expected radius; **no dot ever on an occupied target**; capture drawn as square-minus-circle with the circle as subtrahend; **subtracted radius stays above half a square** (the bleed guard); positions mirror when flipped; a wide-open queen's full 27 targets all draw.

**Layering**: resting layer holds all 32 pieces; lifting one moves it out of the resting layer and into the raised one; and in a full `SkiaBoard` render the dots land between the two atlases in paint order.

Full suite: 281 passed, 18 suites. Verified on an iPhone 17 simulator throughout — including frame-by-frame checks of the stagger and dismissal on deliberately slowed timings.

🤖 Generated with [Claude Code](https://claude.com/claude-code)