### PR TITLE
fix: validate drops against the position, not the selection

### DIFF
--- a/src/__tests__/board-memoization.test.tsx
+++ b/src/__tests__/board-memoization.test.tsx
@@ -15,6 +15,7 @@ import type {
   HighlightState,
 } from '../state/types';
 import { SQUARES } from '../state/types';
+import { collectLegalTargets } from '../helpers/collect-legal-targets';
 import {
   MOVE_SPRING,
   SCALE_SPRING,
@@ -89,6 +90,7 @@ const makeBoardState = (): BoardState => {
     lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
     isCheck: makeMutable(false),
     kingInCheckSquare: makeMutable<Square | null>(null),
+    legalTargets: makeMutable(collectLegalTargets(chess)),
   };
 };
 

--- a/src/__tests__/drag-lifecycle.test.tsx
+++ b/src/__tests__/drag-lifecycle.test.tsx
@@ -17,6 +17,7 @@ import type {
   HighlightState,
 } from '../state/types';
 import { SQUARES } from '../state/types';
+import { collectLegalTargets } from '../helpers/collect-legal-targets';
 import {
   MOVE_SPRING,
   SCALE_SPRING,
@@ -60,6 +61,7 @@ const createMockBoardState = (chess: Chess): BoardState => {
     lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
     isCheck: makeMutable(false),
     kingInCheckSquare: makeMutable<Square | null>(null),
+    legalTargets: makeMutable(collectLegalTargets(chess)),
   };
 };
 
@@ -174,6 +176,85 @@ describe('drag lifecycle', () => {
     // The in-flight animation is left alone.
     expect(square.zIndex.get()).toBe(100);
     expect(square.translateY.get()).toBe(e2Origin.y - PIECE_SIZE);
+  });
+
+  describe('drop validation', () => {
+    // `selectPiece` runs on the JS thread, one scheduleOnRN hop after
+    // `onStart` asks for it. A fast drag reaches `onEnd` before that lands,
+    // so `validMoves` still holds the PREVIOUS selection — or nothing. The
+    // drop must be judged against the position instead. These tests model
+    // that by never letting `validMoves` catch up.
+    const E4 = 'e4' as Square;
+    const e4Origin = squareToPosition(E4, PIECE_SIZE, false);
+    const e4Center = {
+      x: e4Origin.x + PIECE_SIZE / 2,
+      y: e4Origin.y + PIECE_SIZE / 2,
+    };
+
+    const dragTo = (
+      pan: MockPanGesture,
+      from: { x: number; y: number },
+      to: { x: number; y: number }
+    ) => {
+      pan.simulateBegin(event(from.x, from.y));
+      pan.simulateStart(event(from.x, from.y));
+      pan.simulateUpdate(event(to.x, to.y));
+      pan.simulateEnd(event(to.x, to.y));
+    };
+
+    it('accepts a legal drop even though validMoves is still empty', () => {
+      const chess = new Chess();
+      const boardState = createMockBoardState(chess);
+      const { pan, moveExecutor } = mountGesture(boardState);
+
+      // Nothing selected yet — exactly the state a first drag starts from.
+      expect(boardState.validMoves.get()).toEqual([]);
+
+      dragTo(pan, e2Center, e4Center);
+
+      expect(moveExecutor.tryMove).toHaveBeenCalledWith(E2, E4);
+    });
+
+    it('accepts a legal drop while another piece is still selected', () => {
+      const chess = new Chess();
+      const boardState = createMockBoardState(chess);
+      const { pan, moveExecutor } = mountGesture(boardState);
+
+      // b1 was tapped a moment ago; its targets are what validMoves holds.
+      boardState.selectedSquare.set('b1' as Square);
+      boardState.validMoves.set(['a3' as Square, 'c3' as Square]);
+
+      dragTo(pan, e2Center, e4Center);
+
+      // e4 is not in b1's targets, but it IS legal for the e2 pawn.
+      expect(moveExecutor.tryMove).toHaveBeenCalledWith(E2, E4);
+    });
+
+    it('rejects an illegal drop even when a stale selection allows it', () => {
+      const chess = new Chess();
+      const boardState = createMockBoardState(chess);
+      const { pan, moveExecutor } = mountGesture(boardState);
+      const square = boardState.squares[E2];
+
+      // The stale list contains the drop square, but the e2 pawn cannot
+      // reach e5. Trusting it animated the piece onto a square chess.js
+      // never moved it to, desyncing the board.
+      boardState.selectedSquare.set('e7' as Square);
+      boardState.validMoves.set(['e5' as Square, 'e6' as Square]);
+
+      const e5Center = {
+        x: e4Center.x,
+        y:
+          squareToPosition('e5' as Square, PIECE_SIZE, false).y +
+          PIECE_SIZE / 2,
+      };
+      dragTo(pan, e2Center, e5Center);
+
+      expect(moveExecutor.tryMove).not.toHaveBeenCalled();
+      // Snapped home rather than left on the illegal square.
+      expect(square.translateX.get()).toBe(e2Origin.x);
+      expect(square.translateY.get()).toBe(e2Origin.y);
+    });
   });
 
   it('clears the drag flag so the next touch starts clean', () => {

--- a/src/__tests__/move-dots.test.tsx
+++ b/src/__tests__/move-dots.test.tsx
@@ -14,6 +14,7 @@ import type {
   HighlightState,
 } from '../state/types';
 import { SQUARES } from '../state/types';
+import { collectLegalTargets } from '../helpers/collect-legal-targets';
 import {
   MOVE_SPRING,
   SCALE_SPRING,
@@ -83,6 +84,7 @@ const makeBoardState = (fen?: string): BoardState => {
     lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
     isCheck: makeMutable(false),
     kingInCheckSquare: makeMutable<Square | null>(null),
+    legalTargets: makeMutable(collectLegalTargets(chess)),
   };
 };
 

--- a/src/__tests__/move-executor.test.ts
+++ b/src/__tests__/move-executor.test.ts
@@ -9,6 +9,7 @@ import type {
   HighlightState,
 } from '../state/types';
 import { SQUARES } from '../state/types';
+import { collectLegalTargets } from '../helpers/collect-legal-targets';
 import {
   MOVE_SPRING,
   SCALE_SPRING,
@@ -64,6 +65,7 @@ const createMockBoardState = (chess: Chess, pieceSize: number): BoardState => {
     lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
     isCheck: makeMutable(false),
     kingInCheckSquare: makeMutable<Square | null>(null),
+    legalTargets: makeMutable(collectLegalTargets(chess)),
   };
 };
 

--- a/src/__tests__/performance.test.ts
+++ b/src/__tests__/performance.test.ts
@@ -7,6 +7,7 @@ import type {
   HighlightState,
 } from '../state/types';
 import { SQUARES } from '../state/types';
+import { collectLegalTargets } from '../helpers/collect-legal-targets';
 import {
   MOVE_SPRING,
   SCALE_SPRING,
@@ -62,6 +63,7 @@ const createMockBoardState = (chess: Chess, pieceSize: number): BoardState => {
     lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
     isCheck: makeMutable(false),
     kingInCheckSquare: makeMutable<Square | null>(null),
+    legalTargets: makeMutable(collectLegalTargets(chess)),
   };
 };
 

--- a/src/__tests__/promotion-cancel.test.ts
+++ b/src/__tests__/promotion-cancel.test.ts
@@ -13,6 +13,7 @@ import type {
   BoardConfig,
 } from '../state/types';
 import { SQUARES } from '../state/types';
+import { collectLegalTargets } from '../helpers/collect-legal-targets';
 import {
   MOVE_SPRING,
   SCALE_SPRING,
@@ -62,6 +63,7 @@ const createMockBoardState = (chess: Chess, pieceSize: number): BoardState => {
     lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
     isCheck: makeMutable(false),
     kingInCheckSquare: makeMutable<Square | null>(null),
+    legalTargets: makeMutable(collectLegalTargets(chess)),
   };
 };
 

--- a/src/__tests__/render-effect-reset.test.ts
+++ b/src/__tests__/render-effect-reset.test.ts
@@ -12,6 +12,7 @@ import type {
   BoardConfig,
 } from '../state/types';
 import { SQUARES } from '../state/types';
+import { collectLegalTargets } from '../helpers/collect-legal-targets';
 import { squareToPosition } from '../state/use-board-state';
 import {
   MOVE_SPRING,
@@ -61,6 +62,7 @@ const createMockBoardState = (chess: Chess): BoardState => {
     lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
     isCheck: makeMutable(false),
     kingInCheckSquare: makeMutable<Square | null>(null),
+    legalTargets: makeMutable(collectLegalTargets(chess)),
   };
 };
 

--- a/src/__tests__/use-board-gesture.test.ts
+++ b/src/__tests__/use-board-gesture.test.ts
@@ -7,6 +7,7 @@ import type {
   HighlightState,
 } from '../state/types';
 import { SQUARES } from '../state/types';
+import { collectLegalTargets } from '../helpers/collect-legal-targets';
 import { positionToSquare, squareToPosition } from '../state/use-board-state';
 
 // Helper to create mock square state
@@ -58,6 +59,7 @@ const createMockBoardState = (chess: Chess, pieceSize: number): BoardState => {
     lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
     isCheck: makeMutable(false),
     kingInCheckSquare: makeMutable<Square | null>(null),
+    legalTargets: makeMutable(collectLegalTargets(chess)),
   };
 };
 

--- a/src/__tests__/use-board-state.test.ts
+++ b/src/__tests__/use-board-state.test.ts
@@ -7,6 +7,7 @@ import type {
   BoardState,
 } from '../state/types';
 import { SQUARES } from '../state/types';
+import { collectLegalTargets } from '../helpers/collect-legal-targets';
 import { squareToPosition } from '../state/use-board-state';
 
 // Helper to create a board state similar to useBoardState
@@ -53,6 +54,7 @@ const createBoardState = (
     lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
     isCheck: makeMutable(false),
     kingInCheckSquare: makeMutable<Square | null>(null),
+    legalTargets: makeMutable(collectLegalTargets(chess)),
   };
 
   return { boardState, chess };

--- a/src/__tests__/use-chessboard-ref.test.ts
+++ b/src/__tests__/use-chessboard-ref.test.ts
@@ -7,6 +7,7 @@ import type {
   HighlightState,
 } from '../state/types';
 import { SQUARES } from '../state/types';
+import { collectLegalTargets } from '../helpers/collect-legal-targets';
 import { createMoveExecutor } from '../state/move-executor';
 import { getChessboardState } from '../helpers/get-chessboard-state';
 import {
@@ -64,6 +65,7 @@ const createMockBoardState = (chess: Chess, pieceSize: number): BoardState => {
     lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
     isCheck: makeMutable(false),
     kingInCheckSquare: makeMutable<Square | null>(null),
+    legalTargets: makeMutable(collectLegalTargets(chess)),
   };
 };
 

--- a/src/helpers/collect-legal-targets.ts
+++ b/src/helpers/collect-legal-targets.ts
@@ -1,0 +1,30 @@
+import type { Chess, Square } from 'chess.js';
+import type { LegalTargets } from '../state/types';
+
+/**
+ * Every legal move in the current position, grouped by origin square.
+ *
+ * The gesture handler needs to judge a drop on the UI thread, but legality
+ * lives in chess.js on the JS thread. Publishing the whole position's moves
+ * whenever it changes means the drop never has to wait for a round trip —
+ * which is what previously let a fast drag be validated against the
+ * previously selected piece (or against nothing at all).
+ *
+ * One `moves()` call for the whole board, not one per square: chess.js
+ * generates all of them anyway, so grouping is far cheaper than 64 calls.
+ */
+export const collectLegalTargets = (chess: Chess): LegalTargets => {
+  const targets: LegalTargets = {};
+
+  for (const move of chess.moves({ verbose: true })) {
+    const from = move.from as Square;
+    const existing = targets[from];
+    if (existing) {
+      existing.push(move.to as Square);
+    } else {
+      targets[from] = [move.to as Square];
+    }
+  }
+
+  return targets;
+};

--- a/src/hooks/use-board-gesture.ts
+++ b/src/hooks/use-board-gesture.ts
@@ -178,9 +178,16 @@ export const useBoardGesture = ({
           flipped
         );
 
-        const validMoves = boardState.validMoves.get();
+        // Judge the drop against the position's own legality map, NOT against
+        // `validMoves`. `validMoves` is written by `selectPiece` on the JS
+        // thread, one `scheduleOnRN` hop after `onStart` asks for it — so a
+        // fast drag reaches `onEnd` while it still holds the previous
+        // selection's targets, or nothing at all. That silently threw away
+        // legal moves, and when the stale list happened to contain the drop
+        // square it animated the piece to a square chess.js never moved it to.
+        const targets = boardState.legalTargets.get()[square] ?? [];
         const isValidMove =
-          targetSquare !== square && validMoves.includes(targetSquare);
+          targetSquare !== square && targets.includes(targetSquare);
 
         if (isValidMove) {
           const targetPos = squareToPosition(targetSquare, pieceSize, flipped);

--- a/src/state/move-executor.ts
+++ b/src/state/move-executor.ts
@@ -11,6 +11,7 @@ import {
   ChessboardState,
 } from '../helpers/get-chessboard-state';
 import { findKingSquare } from '../helpers/find-king-square';
+import { collectLegalTargets } from '../helpers/collect-legal-targets';
 
 export type MoveResult = {
   move: Move;
@@ -209,6 +210,8 @@ export const createMoveExecutor = (
 
     // Update board state
     boardState.turn.set(chess.turn());
+    // The position changed, so the gesture handler's legality map is stale.
+    boardState.legalTargets.set(collectLegalTargets(chess));
     boardState.selectedSquare.set(null);
     boardState.validMoves.set([]);
     updateHighlightsAfterMove(from, to);
@@ -406,6 +409,8 @@ export const createMoveExecutor = (
 
     // Reset other state
     boardState.turn.set(chess.turn());
+    // The position changed, so the gesture handler's legality map is stale.
+    boardState.legalTargets.set(collectLegalTargets(chess));
     boardState.selectedSquare.set(null);
     boardState.validMoves.set([]);
     boardState.lastMove.set(lastMove);

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -34,12 +34,27 @@ export interface HighlightState {
   color: SharedValue<string | null>;
 }
 
+/** Legal destinations for the side to move, keyed by origin square. */
+export type LegalTargets = Partial<Record<Square, Square[]>>;
+
 export interface BoardState {
   squares: Record<Square, SquareState>;
   highlights: Record<Square, HighlightState>;
   turn: SharedValue<Color>;
   selectedSquare: SharedValue<Square | null>;
+  /**
+   * Targets of the CURRENTLY SELECTED piece — what the dots draw. Written from
+   * the JS thread by `selectPiece`, so it lags a gesture by a round trip and
+   * must never be used to judge a drop. See `legalTargets`.
+   */
   validMoves: SharedValue<Square[]>;
+  /**
+   * Every legal move in the position, by origin square. Refreshed whenever the
+   * position changes, so the gesture handler can validate a drop entirely on
+   * the UI thread — without waiting for `selectPiece` to round-trip through
+   * JS, which is what let fast drags be judged against a stale selection.
+   */
+  legalTargets: SharedValue<LegalTargets>;
   lastMove: SharedValue<{ from: Square; to: Square } | null>;
   isCheck: SharedValue<boolean>;
   kingInCheckSquare: SharedValue<Square | null>;

--- a/src/state/use-board-state.ts
+++ b/src/state/use-board-state.ts
@@ -10,6 +10,8 @@ import type {
   HighlightState,
 } from './types';
 import { SQUARES } from './types';
+import type { LegalTargets } from './types';
+import { collectLegalTargets } from '../helpers/collect-legal-targets';
 
 const squareToIndex = (
   square: Square,
@@ -136,6 +138,11 @@ export const useBoardState = (
   const lastMove = useSharedValue<{ from: Square; to: Square } | null>(null);
   const isCheck = useSharedValue(chess.isCheck());
   const kingInCheckSquare = useSharedValue<Square | null>(null);
+  // Seeded from the initial position; the executor refreshes it after every
+  // move, and the fen effect below after every prop-driven reset.
+  const legalTargets = useSharedValue<LegalTargets>(
+    collectLegalTargets(chessRef.current)
+  );
 
   // Latest layout, read by the fen-reset effect WITHOUT subscribing to it.
   // The fen effect resets the board to `initialFen`; layout changes (flip /
@@ -199,6 +206,9 @@ export const useBoardState = (
     const positions = SQUARES.map((square) => squareToPosition(square, ps, fl));
     const nextTurn = chess.turn();
     const nextIsCheck = chess.isCheck();
+    // The position just changed under the board, so the cached legality map
+    // belongs to the old one.
+    legalTargets.set(collectLegalTargets(chess));
 
     // Commit every square in a single UI-runtime transaction. Setting each
     // field from JS schedules hundreds of independent updates, and Skia is
@@ -245,6 +255,7 @@ export const useBoardState = (
     lastMove,
     isCheck,
     kingInCheckSquare,
+    legalTargets,
   ]);
 
   const boardState = useMemo(
@@ -257,6 +268,7 @@ export const useBoardState = (
       lastMove,
       isCheck,
       kingInCheckSquare,
+      legalTargets,
     }),
     [
       squareStates,
@@ -267,6 +279,7 @@ export const useBoardState = (
       lastMove,
       isCheck,
       kingInCheckSquare,
+      legalTargets,
     ]
   );
 


### PR DESCRIPTION
## Problem

`onEnd` decided whether a drop was legal by reading `boardState.validMoves`:

```ts
const validMoves = boardState.validMoves.get();
const isValidMove = targetSquare !== square && validMoves.includes(targetSquare);
```

`validMoves` belongs to the **selection**, and only the JS thread writes it — `onStart` asks for it via `scheduleOnRN(handleSelectPiece, ...)`. `onEnd` runs on the **UI thread** with no synchronisation between them, so a drop can be judged against whatever the list held before: the previously selected piece's targets, or an empty list when nothing was selected.

Two failure modes:

1. **Legal move silently discarded** — the stale list omits the drop square. The consumer also receives a spurious `onIllegalMove`.
2. **Board desyncs from chess.js** — the stale list happens to *contain* the drop square. `onEnd` springs the piece to the target and calls `tryMove`, which finds the move illegal and returns `null`; nothing puts the piece back. The sprite sits on a square chess.js says is empty, and stays there until the next reset.

## Fix

Publish the whole position's legal moves, grouped by origin square, as `boardState.legalTargets`. Refreshed wherever the position changes — after a move, after `resetBoard` (which `undo` routes through), and on a `fen` prop change — and read directly by `onEnd`. The UI thread no longer waits on a JS round trip, so the race is **removed** rather than narrowed.

`validMoves` keeps its existing job of driving the move dots.

Cost: one `chess.moves({ verbose: true })` per position change, grouped by origin. chess.js generates them all anyway, so this is much cheaper than asking per square — and it replaces the per-selection call that previously ran on every tap.

## Honest scoping

This came out of reading the code while chasing a report of "can't select a piece while another is selected". **It is not confirmed to be that report's cause.** My attempted device reproduction turned out to be a synthetic-input artifact: a 3-event flick at 0ms never crosses `minDistance(5)`, so no pan starts and the tap handler simply selects the square — which produced the same "no move" result on both the broken and fixed builds. Real drags worked before this change and work after it.

What *is* solid: the ordering hazard is plain in the code, and the new tests fail deterministically without the fix.

## Tests

New `drop validation` block in `drag-lifecycle.test.tsx`, driving the real pan gesture with `validMoves` deliberately never catching up:

- a legal drop is accepted while `validMoves` is still empty (the first-drag case)
- a legal drop is accepted while a *different* piece is still selected
- an illegal drop is rejected even when a stale selection lists it, and the piece snaps home instead of being stranded on a square it never legally reached

All three fail on `main` and pass here. Existing fixtures across ten test files were updated to seed the new field. Full suite: 284 passed, 18 suites. Verified on an iPhone 17 simulator that ordinary drag-to-move still works.

🤖 Generated with [Claude Code](https://claude.com/claude-code)