### PR TITLE
fix: promotion dialog on ios (#59)

### DIFF
--- a/src/__tests__/board-background.test.tsx
+++ b/src/__tests__/board-background.test.tsx
@@ -23,6 +23,7 @@ const baseConfig = (overrides: Partial<BoardConfig> = {}): BoardConfig => ({
     black: '#000',
     lastMoveHighlight: 'rgba(255,255,0,0.5)',
     checkmateHighlight: '#E84855',
+    selectedHighlight: 'rgba(20,120,20,0.35)',
     promotionPieceButton: '#FF9B71',
   },
   animations: {

--- a/src/__tests__/board-memoization.test.tsx
+++ b/src/__tests__/board-memoization.test.tsx
@@ -48,6 +48,7 @@ const makeConfig = (overrides: Partial<BoardConfig> = {}): BoardConfig => ({
     black: '#000',
     lastMoveHighlight: 'rgba(255,255,0,0.5)',
     checkmateHighlight: '#E84855',
+    selectedHighlight: 'rgba(20,120,20,0.35)',
     promotionPieceButton: '#FF9B71',
   },
   animations: {

--- a/src/__tests__/drag-lifecycle.test.tsx
+++ b/src/__tests__/drag-lifecycle.test.tsx
@@ -77,6 +77,7 @@ const config: BoardConfig = {
     black: '#b58863',
     lastMoveHighlight: 'rgba(255, 255, 0, 0.4)',
     checkmateHighlight: 'rgba(255, 0, 0, 0.4)',
+    selectedHighlight: 'rgba(20,120,20,0.35)',
     promotionPieceButton: 'rgba(255, 255, 255, 0.8)',
   },
   animations: {

--- a/src/__tests__/move-dots.test.tsx
+++ b/src/__tests__/move-dots.test.tsx
@@ -42,6 +42,7 @@ const makeConfig = (overrides: Partial<BoardConfig> = {}): BoardConfig => ({
     black: '#000',
     lastMoveHighlight: 'rgba(255,255,0,0.5)',
     checkmateHighlight: '#E84855',
+    selectedHighlight: 'rgba(20,120,20,0.35)',
     promotionPieceButton: '#FF9B71',
   },
   animations: {

--- a/src/__tests__/move-executor.test.ts
+++ b/src/__tests__/move-executor.test.ts
@@ -83,6 +83,7 @@ describe('createMoveExecutor', () => {
       black: '#b58863',
       lastMoveHighlight: 'rgba(255, 255, 0, 0.4)',
       checkmateHighlight: 'rgba(255, 0, 0, 0.4)',
+      selectedHighlight: 'rgba(20,120,20,0.35)',
       promotionPieceButton: 'rgba(255, 255, 255, 0.8)',
     },
     animations: {

--- a/src/__tests__/promotion-cancel.test.ts
+++ b/src/__tests__/promotion-cancel.test.ts
@@ -79,6 +79,7 @@ const config: BoardConfig = {
     black: '#000',
     lastMoveHighlight: 'rgba(255,255,0,0.5)',
     checkmateHighlight: '#E84855',
+    selectedHighlight: 'rgba(20,120,20,0.35)',
     promotionPieceButton: '#FF9B71',
   },
   animations: {

--- a/src/__tests__/render-effect-reset.test.ts
+++ b/src/__tests__/render-effect-reset.test.ts
@@ -78,6 +78,7 @@ const config: BoardConfig = {
     black: '#000',
     lastMoveHighlight: 'rgba(255,255,0,0.5)',
     checkmateHighlight: '#E84855',
+    selectedHighlight: 'rgba(20,120,20,0.35)',
     promotionPieceButton: '#FF9B71',
   },
   animations: {

--- a/src/__tests__/skia-highlights.test.tsx
+++ b/src/__tests__/skia-highlights.test.tsx
@@ -1,0 +1,156 @@
+import React from 'react';
+import { Chess, Square } from 'chess.js';
+import { makeMutable } from 'react-native-reanimated';
+import { SkiaHighlights } from '../components/skia/skia-highlights';
+import { squareToPosition } from '../state/use-board-state';
+import type {
+  BoardConfig,
+  BoardState,
+  PieceCode,
+  SquareState,
+  HighlightState,
+} from '../state/types';
+import { SQUARES } from '../state/types';
+import { collectLegalTargets } from '../helpers/collect-legal-targets';
+import {
+  MOVE_SPRING,
+  SCALE_SPRING,
+  SNAP_BACK_SPRING,
+} from '../config/animations';
+import { findAllByType, renderToTree } from './render-utils';
+
+const PIECE_SIZE = 50;
+
+const makeConfig = (overrides: Partial<BoardConfig> = {}): BoardConfig => ({
+  boardSize: PIECE_SIZE * 8,
+  pieceSize: PIECE_SIZE,
+  gestureEnabled: true,
+  flipped: false,
+  withLetters: false,
+  withNumbers: false,
+  colors: {
+    white: '#fff',
+    black: '#000',
+    lastMoveHighlight: 'rgba(255,255,0,0.5)',
+    checkmateHighlight: '#E84855',
+    selectedHighlight: 'rgba(20,120,20,0.35)',
+    promotionPieceButton: '#FF9B71',
+  },
+  animations: {
+    move: MOVE_SPRING,
+    scale: SCALE_SPRING,
+    snapBack: SNAP_BACK_SPRING,
+  },
+  fontSource: null,
+  ...overrides,
+});
+
+const makeBoardState = (fen?: string): BoardState => {
+  const chess = new Chess(fen);
+  const squares: Partial<Record<Square, SquareState>> = {};
+  const highlights: Partial<Record<Square, HighlightState>> = {};
+
+  for (const square of SQUARES) {
+    const { x, y } = squareToPosition(square, PIECE_SIZE, false);
+    const piece = chess.get(square);
+    squares[square] = {
+      piece: makeMutable<PieceCode>(
+        piece ? (`${piece.color}${piece.type}` as PieceCode) : null
+      ),
+      translateX: makeMutable(x),
+      translateY: makeMutable(y),
+      scale: makeMutable(1),
+      zIndex: makeMutable(0),
+      lastMove: makeMutable(false),
+      inCheck: makeMutable(false),
+    };
+    highlights[square] = { color: makeMutable<string | null>(null) };
+  }
+
+  return {
+    squares: squares as Record<Square, SquareState>,
+    highlights: highlights as Record<Square, HighlightState>,
+    turn: makeMutable(chess.turn()),
+    selectedSquare: makeMutable<Square | null>(null),
+    validMoves: makeMutable<Square[]>([]),
+    lastMove: makeMutable<{ from: Square; to: Square } | null>(null),
+    isCheck: makeMutable(false),
+    kingInCheckSquare: makeMutable<Square | null>(null),
+    legalTargets: makeMutable(collectLegalTargets(chess)),
+  };
+};
+
+type RectProps = {
+  x: number;
+  y: number;
+  color: string;
+  opacity: { get(): number };
+};
+
+/** Every highlight rect for `square`, in paint order. */
+const rectsAt = (
+  boardState: BoardState,
+  square: Square,
+  config: BoardConfig = makeConfig()
+): RectProps[] => {
+  const { x, y } = squareToPosition(square, PIECE_SIZE, config.flipped);
+  return findAllByType(
+    renderToTree(<SkiaHighlights config={config} boardState={boardState} />),
+    'skia-rect'
+  )
+    .map((node) => node.props as unknown as RectProps)
+    .filter((props) => props.x === x && props.y === y);
+};
+
+describe('SkiaHighlights selection', () => {
+  it('is transparent on every square when nothing is selected', () => {
+    const boardState = makeBoardState();
+    const rects = rectsAt(boardState, 'e2' as Square);
+
+    expect(rects.length).toBeGreaterThan(0);
+    for (const rect of rects) {
+      expect(rect.opacity.get()).toBe(0);
+    }
+  });
+
+  it('lights up the selected square with the selection color', () => {
+    const boardState = makeBoardState();
+    boardState.selectedSquare.set('e2' as Square);
+
+    const config = makeConfig();
+    const rects = rectsAt(boardState, 'e2' as Square, config);
+    const selectionRect = rects.find(
+      (r) => r.color === config.colors.selectedHighlight
+    );
+
+    expect(selectionRect).toBeDefined();
+    expect(selectionRect?.opacity.get()).toBe(1);
+  });
+
+  it('does not light up a square other than the selected one', () => {
+    const boardState = makeBoardState();
+    boardState.selectedSquare.set('e2' as Square);
+
+    const config = makeConfig();
+    const rects = rectsAt(boardState, 'd4' as Square, config);
+    const selectionRect = rects.find(
+      (r) => r.color === config.colors.selectedHighlight
+    );
+
+    expect(selectionRect?.opacity.get()).toBe(0);
+  });
+
+  it('clears the selection highlight once deselected', () => {
+    const boardState = makeBoardState();
+    boardState.selectedSquare.set('e2' as Square);
+    boardState.selectedSquare.set(null);
+
+    const config = makeConfig();
+    const rects = rectsAt(boardState, 'e2' as Square, config);
+    const selectionRect = rects.find(
+      (r) => r.color === config.colors.selectedHighlight
+    );
+
+    expect(selectionRect?.opacity.get()).toBe(0);
+  });
+});

--- a/src/__tests__/use-chessboard-ref.test.ts
+++ b/src/__tests__/use-chessboard-ref.test.ts
@@ -82,6 +82,7 @@ const config = {
     black: '#b58863',
     lastMoveHighlight: 'rgba(255, 255, 0, 0.4)',
     checkmateHighlight: 'rgba(255, 0, 0, 0.4)',
+    selectedHighlight: 'rgba(20,120,20,0.35)',
     promotionPieceButton: 'rgba(255, 255, 255, 0.8)',
   },
   animations: {

--- a/src/components/promotion-dialog.tsx
+++ b/src/components/promotion-dialog.tsx
@@ -5,6 +5,7 @@ import {
   Image,
   Modal,
   Pressable,
+  useWindowDimensions,
 } from 'react-native';
 import type { PieceSymbol } from 'chess.js';
 import Animated, { FadeIn, FadeOut } from 'react-native-reanimated';
@@ -22,7 +23,6 @@ interface PromotionDialogProps {
 
 const styles = StyleSheet.create({
   overlay: {
-    ...StyleSheet.absoluteFillObject,
     backgroundColor: 'rgba(0, 0, 0, 0.5)',
     justifyContent: 'center',
     alignItems: 'center',
@@ -52,10 +52,21 @@ const styles = StyleSheet.create({
 export const PromotionDialog: React.FC<PromotionDialogProps> = React.memo(
   ({ color, onSelect, onCancel, config }) => {
     const { colors } = config;
+    // On Fabric, a Modal mounted below the app root can have its native host
+    // view size to its own content instead of the screen - `absoluteFillObject`
+    // (100%/100%) then just fills that collapsed size, leaving `justifyContent:
+    // 'center'` with no extra room to center in (confirmed live: the dialog
+    // rendered full-width but pinned to the very top instead of centered).
+    // Explicit pixel dimensions give Yoga concrete numbers instead of a
+    // percentage that depends on a parent size that never gets set correctly.
+    const { width, height } = useWindowDimensions();
 
     return (
       <Modal transparent visible animationType="fade" onRequestClose={onCancel}>
-        <Pressable style={styles.overlay} onPress={onCancel}>
+        <Pressable
+          style={[styles.overlay, { width, height }]}
+          onPress={onCancel}
+        >
           <Animated.View
             entering={FadeIn.duration(200)}
             exiting={FadeOut.duration(200)}

--- a/src/components/skia/gesture-board.tsx
+++ b/src/components/skia/gesture-board.tsx
@@ -243,19 +243,27 @@ export const GestureBoard = forwardRef<ChessboardRef, GestureBoardProps>(
     );
 
     return (
-      <GestureHandlerRootView style={containerStyle}>
-        <GestureDetector gesture={gesture}>
-          <View style={containerStyle}>
-            <SkiaBoard
-              config={config}
-              boardState={boardState}
-              spriteImage={spriteImage}
-              renderEffect={renderEffect}
-              effectParams={effectParams}
-            />
-          </View>
-        </GestureDetector>
+      <>
+        <GestureHandlerRootView style={containerStyle}>
+          <GestureDetector gesture={gesture}>
+            <View style={containerStyle}>
+              <SkiaBoard
+                config={config}
+                boardState={boardState}
+                spriteImage={spriteImage}
+                renderEffect={renderEffect}
+                effectParams={effectParams}
+              />
+            </View>
+          </GestureDetector>
+        </GestureHandlerRootView>
         {showPromotion && promotionInfoRef.current && (
+          // Deliberately a sibling of GestureHandlerRootView, not a child: that
+          // root view is sized to the board square (`containerStyle`), not the
+          // full screen. PromotionDialog's Modal only needs Pressable/
+          // TouchableOpacity, no gesture-handler gestures, so nesting it inside
+          // just constrained its presented layout to the board's bounds instead
+          // of the full window.
           <PromotionDialog
             color={promotionInfoRef.current.color}
             onSelect={handlePromotionSelect}
@@ -263,7 +271,7 @@ export const GestureBoard = forwardRef<ChessboardRef, GestureBoardProps>(
             config={config}
           />
         )}
-      </GestureHandlerRootView>
+      </>
     );
   }
 );

--- a/src/components/skia/skia-highlights.tsx
+++ b/src/components/skia/skia-highlights.tsx
@@ -34,6 +34,13 @@ const SquareHighlight: React.FC<SquareHighlightProps> = React.memo(
       withTiming(squareState.inCheck.get() ? 1 : 0, FADE_OPTIONS)
     );
 
+    const selectedOpacity = useDerivedValue(() =>
+      withTiming(
+        boardState.selectedSquare.get() === square ? 1 : 0,
+        FADE_OPTIONS
+      )
+    );
+
     const customColor = useDerivedValue(
       () => highlightState.color.get() ?? 'transparent'
     );
@@ -44,6 +51,14 @@ const SquareHighlight: React.FC<SquareHighlightProps> = React.memo(
 
     return (
       <Group>
+        <Rect
+          x={position.x}
+          y={position.y}
+          width={pieceSize}
+          height={pieceSize}
+          color={colors.selectedHighlight}
+          opacity={selectedOpacity}
+        />
         <Rect
           x={position.x}
           y={position.y}

--- a/src/state/board-state-context.tsx
+++ b/src/state/board-state-context.tsx
@@ -38,6 +38,7 @@ const defaultColors: BoardConfig['colors'] = {
   black: '#62B1A8',
   lastMoveHighlight: 'rgba(255,255,0, 0.5)',
   checkmateHighlight: '#E84855',
+  selectedHighlight: 'rgba(20, 120, 20, 0.35)',
   promotionPieceButton: '#FF9B71',
 };
 

--- a/src/state/types.ts
+++ b/src/state/types.ts
@@ -72,6 +72,7 @@ export interface BoardConfig {
     black: string;
     lastMoveHighlight: string;
     checkmateHighlight: string;
+    selectedHighlight: string;
     promotionPieceButton: string;
   };
   animations: {


### PR DESCRIPTION
There was an issue with promotion dialog on iOS, the dialog shows up at the top instead of center

feat: piece selection highlight (#58)

When piece is selected, the square is now highlighted